### PR TITLE
Modifies the Mpf type to add functionality.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-gmp"
-version = "0.2.9"
+version = "0.2.91"
 authors = [ "thestinger <danielmicay@gmail.com>", "Bartłomiej Kamiński <fizyk20@gmail.com>" ]
 description = "Rust bindings for GMP"
 repository = "https://github.com/fizyk20/rust-gmp"

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -1,8 +1,10 @@
-use libc::{c_double, c_int, c_long, c_ulong, c_void};
+use libc::{c_double, c_int, c_long, c_ulong, c_void,c_char};
 use std::mem::uninitialized;
 use std::cmp;
 use std::cmp::Ordering::{self, Greater, Less, Equal};
 use std::ops::{Div, Mul, Add, Sub, Neg};
+use std::ffi::CString;
+use std::string::String;
 use super::mpz::mp_bitcnt_t;
 
 type mp_exp_t = c_long;
@@ -26,9 +28,15 @@ extern "C" {
     fn __gmpf_get_prec(op: mpf_srcptr) -> mp_bitcnt_t;
     fn __gmpf_set_prec(rop: mpf_ptr, prec: mp_bitcnt_t);
     fn __gmpf_set(rop: mpf_ptr, op: mpf_srcptr);
+
+    fn __gmpf_set_str(rop: mpf_ptr, str: *const c_char,base: c_int);
+    fn __gmpf_set_si(rop: mpf_ptr,op: c_long);
+    fn __gmpf_get_str(str: *const c_char,expptr: *const mp_exp_t,base: i32,n_digits: i32,op: mpf_ptr) -> *mut c_char;
+
     fn __gmpf_cmp(op1: mpf_srcptr, op2: mpf_srcptr) -> c_int;
     fn __gmpf_cmp_d(op1: mpf_srcptr, op2: c_double) -> c_int;
     fn __gmpf_cmp_ui(op1: mpf_srcptr, op2: c_ulong) -> c_int;
+    fn __gmpf_cmp_si(op1: mpf_srcptr, op2: c_long) -> c_int;
     fn __gmpf_reldiff(rop: mpf_ptr, op1: mpf_srcptr, op2: mpf_srcptr);
     fn __gmpf_add(rop: mpf_ptr, op1: mpf_srcptr, op2: mpf_srcptr);
     fn __gmpf_sub(rop: mpf_ptr, op1: mpf_srcptr, op2: mpf_srcptr);
@@ -39,6 +47,7 @@ extern "C" {
     fn __gmpf_ceil(rop: mpf_ptr, op: mpf_srcptr);
     fn __gmpf_floor(rop: mpf_ptr, op: mpf_srcptr);
     fn __gmpf_trunc(rop: mpf_ptr, op: mpf_srcptr);
+    fn __gmpf_sqrt(rop: mpf_ptr, op: mpf_srcptr);
 }
 
 pub struct Mpf {
@@ -52,6 +61,7 @@ impl Drop for Mpf {
 }
 
 impl Mpf {
+    pub fn zero() -> Mpf { Mpf::new(32) }
     pub fn new(precision: usize) -> Mpf {
         unsafe {
             let mut mpf = uninitialized();
@@ -70,6 +80,28 @@ impl Mpf {
 
     pub fn set_prec(&mut self, precision: usize) {
         unsafe { __gmpf_set_prec(&mut self.mpf, precision as c_ulong) }
+    }
+
+    pub fn set_from_str(&mut self,string: &str,base: i32){
+        let c_str = CString::new(string).unwrap();
+        unsafe {
+            __gmpf_set_str(&mut self.mpf, c_str.as_ptr(),base as c_int);
+        }
+    }
+
+    pub fn set_from_si(&mut self,int: i64){
+        unsafe{
+            __gmpf_set_si(&mut self.mpf,int as c_long);
+        }
+    }
+
+    pub fn get_str(&mut self,n_digits: i32,base: i32, exp: &mut c_long) -> String{
+        let c_str = CString::new("").unwrap();
+        let out;
+        unsafe{
+            out = CString::from_raw(__gmpf_get_str(c_str.into_raw(),exp,base,n_digits,&mut self.mpf));
+        }
+        out.to_str().unwrap().to_string()
     }
 
     pub fn abs(&self) -> Mpf {
@@ -110,6 +142,20 @@ impl Mpf {
             __gmpf_reldiff(&mut res.mpf, &self.mpf, &other.mpf);
             res
         }
+    }
+
+    pub fn sqrt(self) -> Mpf {
+        let mut retval:Mpf;
+        unsafe {
+            retval = Mpf::new(__gmpf_get_prec(&self.mpf) as usize);
+            retval.set_from_si(0);
+            if __gmpf_cmp_si(&self.mpf,0) > 0 {
+                __gmpf_sqrt(&mut retval.mpf,&self.mpf);
+            } else {
+                panic!("Square root of negative/zero");
+            }
+        }
+        retval
     }
 }
 


### PR DESCRIPTION
Mpf::zero() creates a new Mpf with value zero
Mpf::set_from_str() sets the Mpf to the value in str in the given base
Mpf::set_from_si() sets the value from a signed int
Mpf::get_str() gets a string of the Mpf, see GMP docs for formatting.
Mpf::sqrt() is self-explanatory

Also increments version number.
