### PR TITLE
Added conversions between mpz::Mpz and byte containers.

### DIFF
--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -675,14 +675,14 @@ impl Neg for Mpz {
 }
 
 // Similarly to mpz_export, this does not preserve the sign of the input.
-impl<'b> Into<Option<Vec<u8>>> for &'b Mpz {
-    fn into(self) -> Option<Vec<u8>> {
+impl<'b> Into<Vec<u8>> for &'b Mpz {
+    fn into(self) -> Vec<u8> {
         unsafe {
             let bit_size = size_of::<u8>() * 8;
             let size = (__gmpz_sizeinbase(&self.mpz, 2) + bit_size - 1) / bit_size;
             let mut result: Vec<u8> = vec!(0; size);
             __gmpz_export(result.as_mut_ptr() as *mut c_void, 0 as *mut size_t, 1, size_of::<u8>() as size_t, 0, 0, &self.mpz);
-            Some(result)
+            result
         }
     }
 }

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -674,6 +674,19 @@ impl Neg for Mpz {
     }
 }
 
+// Similarly to mpz_export, this does not preserve the sign of the input.
+impl<'b> Into<Option<Vec<u8>>> for &'b Mpz {
+    fn into(self) -> Option<Vec<u8>> {
+        unsafe {
+            let bit_size = size_of::<u8>() * 8;
+            let size = (__gmpz_sizeinbase(&self.mpz, 2) + bit_size - 1) / bit_size;
+            let mut result: Vec<u8> = vec!(0; size);
+            __gmpz_export(result.as_mut_ptr() as *mut c_void, 0 as *mut size_t, -1, size_of::<u8>() as size_t, 0, 0, &self.mpz);
+            Some(result)
+        }
+    }
+}
+
 impl<'b> Into<Option<i64>> for &'b Mpz {
     fn into(self) -> Option<i64> {
         unsafe {

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -723,6 +723,17 @@ impl<'a> Into<f64> for &'a Mpz {
     }
 }
 
+impl<'a> From<&'a [u8]> for Mpz {
+    fn from(other: &'a [u8]) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+            __gmpz_import(&mut res.mpz, other.len(), 1, size_of::<u8>() as size_t,
+                          0, 0, other.as_ptr() as *const c_void);
+            res
+        }
+    }
+}
+
 impl From<u64> for Mpz {
     fn from(other: u64) -> Mpz {
         unsafe {

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -681,7 +681,7 @@ impl<'b> Into<Option<Vec<u8>>> for &'b Mpz {
             let bit_size = size_of::<u8>() * 8;
             let size = (__gmpz_sizeinbase(&self.mpz, 2) + bit_size - 1) / bit_size;
             let mut result: Vec<u8> = vec!(0; size);
-            __gmpz_export(result.as_mut_ptr() as *mut c_void, 0 as *mut size_t, -1, size_of::<u8>() as size_t, 0, 0, &self.mpz);
+            __gmpz_export(result.as_mut_ptr() as *mut c_void, 0 as *mut size_t, 1, size_of::<u8>() as size_t, 0, 0, &self.mpz);
             Some(result)
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -490,13 +490,13 @@ mod mpz {
         let xffff: Mpz = From::<i64>::from(65535);
         let max_u64: Mpz = From::<u64>::from(u64::MAX);
 
-        assert_eq!(Into::<Option<Vec<u8>>>::into(&minus_five), Some(vec!(5u8)));
-        assert_eq!(Into::<Option<Vec<u8>>>::into(&minus_one), Some(vec!(1u8)));
-        assert_eq!(Into::<Option<Vec<u8>>>::into(&zero), Some(vec!(0u8)));
-        assert_eq!(Into::<Option<Vec<u8>>>::into(&one), Some(vec!(1u8)));
-        assert_eq!(Into::<Option<Vec<u8>>>::into(&five), Some(vec!(5u8)));
-        assert_eq!(Into::<Option<Vec<u8>>>::into(&xffff), Some(vec!(255u8, 255u8)));
-        assert_eq!(Into::<Option<Vec<u8>>>::into(&max_u64), Some(vec!(255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8)));
+        assert_eq!(Into::<Vec<u8>>::into(&minus_five), vec!(5u8));
+        assert_eq!(Into::<Vec<u8>>::into(&minus_one), vec!(1u8));
+        assert_eq!(Into::<Vec<u8>>::into(&zero), vec!(0u8));
+        assert_eq!(Into::<Vec<u8>>::into(&one), vec!(1u8));
+        assert_eq!(Into::<Vec<u8>>::into(&five), vec!(5u8));
+        assert_eq!(Into::<Vec<u8>>::into(&xffff), vec!(255u8, 255u8));
+        assert_eq!(Into::<Vec<u8>>::into(&max_u64), vec!(255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8));
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -188,6 +188,13 @@ mod mpz {
     }
 
     #[test]
+    fn test_from_slice_u8() {
+        let v: Vec<u8> = vec!(255, 255);
+        let x: Mpz = From::from(&v[..]);
+        assert!(x.to_string() == "65535".to_string());
+    }
+
+    #[test]
     fn test_abs() {
         let x: Mpz = From::<i64>::from(1000);
         let y: Mpz = From::<i64>::from(-1000);

--- a/src/test.rs
+++ b/src/test.rs
@@ -479,6 +479,26 @@ mod mpz {
         assert_eq!(hash(&a), hash(&(&b + &one)));
         assert_eq!(hash(&(&a - &a)), hash(&(&one - &one)));
     }
+
+    #[test]
+    fn test_to_vec_u8() {
+        let minus_five: Mpz = From::<i64>::from(-5);
+        let minus_one: Mpz = From::<i64>::from(-1);
+        let zero: Mpz = From::<i64>::from(0);
+        let one: Mpz = From::<i64>::from(1);
+        let five: Mpz = From::<i64>::from(5);
+        let xffff: Mpz = From::<i64>::from(65535);
+        let max_u64: Mpz = From::<u64>::from(u64::MAX);
+
+        assert_eq!(Into::<Option<Vec<u8>>>::into(&minus_five), Some(vec!(5u8)));
+        assert_eq!(Into::<Option<Vec<u8>>>::into(&minus_one), Some(vec!(1u8)));
+        assert_eq!(Into::<Option<Vec<u8>>>::into(&zero), Some(vec!(0u8)));
+        assert_eq!(Into::<Option<Vec<u8>>>::into(&one), Some(vec!(1u8)));
+        assert_eq!(Into::<Option<Vec<u8>>>::into(&five), Some(vec!(5u8)));
+        assert_eq!(Into::<Option<Vec<u8>>>::into(&xffff), Some(vec!(255u8, 255u8)));
+        assert_eq!(Into::<Option<Vec<u8>>>::into(&max_u64), Some(vec!(255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8)));
+    }
+
     #[test]
     fn test_to_u64() {
         let minus_five: Mpz = From::<i64>::from(-5);


### PR DESCRIPTION
- Added conversion from `&[u8] to`mpz::Mpz`.
- Added conversion from `mpz::Mpz` to `Vec<u8>`.
