### PR TITLE
Specify license as MIT in Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 authors = [ "thestinger <danielmicay@gmail.com>", "Bartłomiej Kamiński <fizyk20@gmail.com>" ]
 description = "Rust bindings for GMP"
 repository = "https://github.com/fizyk20/rust-gmp"
-license-file = "LICENSE"
+license = "MIT"
 keywords = [ "gmp", "multi", "precision", "arithmetic", "bignum" ]
 
 [lib]


### PR DESCRIPTION
Specifying a license file explicitly marks the crate as
having a "non-standard" license, which is not the case.
