### PR TITLE
Add `Mpq::ratio()`, `Mpq::canonicalize()`, `Mpq::to_f64()`, and `Mpz::size_in_base()`

### DIFF
--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -37,6 +37,8 @@ extern "C" {
     fn __gmpq_inv(inverted_number: mpq_ptr, number: mpq_srcptr);
     fn __gmpq_get_num(numerator: mpz_ptr, rational: mpq_srcptr);
     fn __gmpq_get_den(denominator: mpz_ptr, rational: mpq_srcptr);
+    fn __gmpq_set_num(rational: mpq_ptr, numerator: mpz_srcptr);
+    fn __gmpq_set_den(rational: mpq_ptr, denominator: mpz_srcptr);
 }
 
 pub struct Mpq {
@@ -63,6 +65,15 @@ impl Mpq {
             let mut mpq = uninitialized();
             __gmpq_init(&mut mpq);
             Mpq { mpq: mpq }
+        }
+    }
+
+    pub fn ratio(num: &Mpz, den: &Mpz) -> Mpq {
+        unsafe {
+            let mut res = Mpq::new();
+            __gmpq_set_num(&mut res.mpq, num.inner());
+            __gmpq_set_den(&mut res.mpq, den.inner());
+            res
         }
     }
 

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -39,6 +39,7 @@ extern "C" {
     fn __gmpq_get_den(denominator: mpz_ptr, rational: mpq_srcptr);
     fn __gmpq_set_num(rational: mpq_ptr, numerator: mpz_srcptr);
     fn __gmpq_set_den(rational: mpq_ptr, denominator: mpz_srcptr);
+    fn __gmpq_canonicalize(rational: mpq_ptr);
 }
 
 pub struct Mpq {
@@ -74,6 +75,12 @@ impl Mpq {
             __gmpq_set_num(&mut res.mpq, num.inner());
             __gmpq_set_den(&mut res.mpq, den.inner());
             res
+        }
+    }
+
+    pub fn canonicalize(&mut self) {
+        unsafe {
+            __gmpq_canonicalize(&mut self.mpq);
         }
     }
 

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -40,6 +40,7 @@ extern "C" {
     fn __gmpq_set_num(rational: mpq_ptr, numerator: mpz_srcptr);
     fn __gmpq_set_den(rational: mpq_ptr, denominator: mpz_srcptr);
     fn __gmpq_canonicalize(rational: mpq_ptr);
+    fn __gmpq_get_d(rational: mpq_srcptr) -> c_double;
 }
 
 pub struct Mpq {
@@ -81,6 +82,12 @@ impl Mpq {
     pub fn canonicalize(&mut self) {
         unsafe {
             __gmpq_canonicalize(&mut self.mpq);
+        }
+    }
+
+    pub fn to_f64(&self) -> f64 {
+        unsafe {
+            __gmpq_get_d(&self.mpq) as f64
         }
     }
 

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -85,12 +85,6 @@ impl Mpq {
         }
     }
 
-    pub fn to_f64(&self) -> f64 {
-        unsafe {
-            __gmpq_get_d(&self.mpq) as f64
-        }
-    }
-
     pub fn set(&mut self, other: &Mpq) {
         unsafe { __gmpq_set(&mut self.mpq, &other.mpq) }
     }
@@ -315,6 +309,14 @@ impl Into<Option<i64>> for Mpq {
 impl Into<Option<u64>> for Mpq {
     fn into(self) -> Option<u64> {
         panic!("not implemented")
+    }
+}
+
+impl Into<f64> for Mpq {
+    fn into(self) -> f64 {
+        unsafe {
+            __gmpq_get_d(&self.mpq) as f64
+        }
     }
 }
 

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -132,6 +132,12 @@ impl Mpz {
         }
     }
 
+    pub fn size_in_base(&self, base: u8) -> usize {
+        unsafe {
+            __gmpz_sizeinbase(&self.mpz, base as c_int) as usize
+        }
+    }
+
     // TODO: fail on an invalid base
     // FIXME: Unfortunately it isn't currently possible to use the fmt::RadixFmt
     //        machinery for a custom type.


### PR DESCRIPTION
These functions were needed in a project of mine.
