### PR TITLE
Add documentation links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.2"
 authors = [ "thestinger <danielmicay@gmail.com>", "Bartłomiej Kamiński <fizyk20@gmail.com>" ]
 description = "Rust bindings for GMP"
 repository = "https://github.com/fizyk20/rust-gmp"
+documentation = "https://docs.rs/rust-gmp"
 license = "MIT"
 keywords = [ "gmp", "multi", "precision", "arithmetic", "bignum" ]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/fizyk20/rust-gmp.svg?branch=master)](https://travis-ci.org/fizyk20/rust-gmp)
 
+[Documentation](https://docs.rs/rust-gmp)
+
 The following functions are intentionally left out of the bindings:
 
 * `gmp_randinit` (not thread-safe, obsolete)


### PR DESCRIPTION
The site https://docs.rs auto-builds documentation for crates on crates.io, so all we have to do is link to it.