### PR TITLE
Implement floor and ceiling for rationals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 Cargo.lock
+*.swp

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,7 @@
+use mpz::*;
+
+#[link(name = "gmp")]
+extern "C" {
+    pub fn __gmpz_fdiv_q(q: mpz_ptr, n: mpz_srcptr, d: mpz_srcptr);
+    pub fn __gmpz_cdiv_q(q: mpz_ptr, n: mpz_srcptr, d: mpz_srcptr);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ macro_rules! gen_overloads {
     }
 }
 
+mod ffi;
 pub mod mpz;
 pub mod mpq;
 pub mod mpf;

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -1,5 +1,6 @@
 use super::mpz::{mpz_struct, Mpz, mpz_ptr, mpz_srcptr};
 use super::mpf::{Mpf, mpf_srcptr};
+use ffi::*;
 use libc::{c_double, c_int, c_ulong};
 use std::convert::{From, Into};
 use std::mem::uninitialized;
@@ -135,6 +136,22 @@ impl Mpq {
             __gmpq_inv(&mut res.mpq, &self.mpq);
             res
         }
+    }
+
+    pub fn floor(&self) -> Mpz {
+        let mut res = Mpz::new();
+        unsafe {
+            __gmpz_fdiv_q(res.inner_mut(), &self.mpq._mp_num, &self.mpq._mp_den);
+        }
+        res
+    }
+
+    pub fn ceil(&self) -> Mpz {
+        let mut res = Mpz::new();
+        unsafe {
+            __gmpz_cdiv_q(res.inner_mut(), &self.mpq._mp_num, &self.mpq._mp_den);
+        }
+        res
     }
 
     pub fn one() -> Mpq {

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -9,6 +9,8 @@ use std::ops::{Div, Mul, Add, Sub, Neg, Shl, Shr, BitXor, BitAnd, BitOr, Rem};
 use std::ffi::CString;
 use std::{u32, i32};
 
+use ffi::*;
+
 #[repr(C)]
 pub struct mpz_struct {
     _mp_alloc: c_int,
@@ -57,7 +59,6 @@ extern "C" {
     fn __gmpz_tdiv_r(r: mpz_ptr, n: mpz_srcptr, d: mpz_srcptr);
     fn __gmpz_tdiv_q_ui(q: mpz_ptr, n: mpz_srcptr, d: c_ulong);
     fn __gmpz_tdiv_r_ui(r: mpz_ptr, n: mpz_srcptr, d: c_ulong);
-    fn __gmpz_fdiv_q(q: mpz_ptr, n: mpz_srcptr, d: mpz_srcptr);
     fn __gmpz_fdiv_r(r: mpz_ptr, n: mpz_srcptr, d: mpz_srcptr);
     fn __gmpz_fdiv_q_2exp(q: mpz_ptr, n: mpz_srcptr, b: mp_bitcnt_t);
     fn __gmpz_mod(r: mpz_ptr, n: mpz_srcptr, d: mpz_srcptr);

--- a/src/test.rs
+++ b/src/test.rs
@@ -559,7 +559,9 @@ mod rand {
 
 mod mpq {
     use std::convert::From;
+    use std::u64;
     use super::super::mpq::Mpq;
+    use super::super::mpz::Mpz;
 
     #[test]
     fn test_one() {
@@ -592,6 +594,28 @@ mod mpq {
         assert_eq!(format!("{:?}", -&fourty), "-40");
         assert_eq!(format!("{:?}", fourty_sixths), "20/3");
         assert_eq!(format!("{:?}", -&fourty_sixths), "-20/3");
+    }
+
+    #[test]
+    fn test_floor() {
+        let half = Mpq::ratio(&Mpz::from(1), &Mpz::from(2));
+        assert_eq!(half.floor(), Mpz::from(0));
+
+        let big = Mpz::from(u64::MAX) * Mpz::from(u64::MAX);
+        let slightly_more_than_one = Mpq::ratio(&(&big + Mpz::from(1)), &big);
+        assert_eq!(slightly_more_than_one.floor(), Mpz::from(1));
+
+        let minus_half = -half;
+        assert_eq!(minus_half.floor(), Mpz::from(-1));
+    }
+
+    #[test]
+    fn test_ceil() {
+        let half = Mpq::ratio(&Mpz::from(1), &Mpz::from(2));
+        assert_eq!(half.ceil(), Mpz::from(1));
+
+        let minus_half = -half;
+        assert_eq!(minus_half.ceil(), Mpz::from(0));
     }
 }
 


### PR DESCRIPTION
This PR implements floor and ceiling functions for the `Mpq` rational type. Doing so required sharing the FFI binding for `mpz_fdiv_q` between the `mpz` (integer) and `mpq` (rational) modules, so it now lives in a private `ffi` module alongside the corresponding ceiling division function. Depending on the long-term goals of this crate, it might make sense to put all the C functions in private modules (I'll create a separate issue).