### PR TITLE
impl for num_traits::{Zero, One}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ name = "gmp"
 
 [dependencies]
 libc = "~0.2"
+num-traits = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(non_camel_case_types)]
 
 extern crate libc;
+extern crate num_traits;
 
 macro_rules! gen_overloads_inner {
     ($tr:ident, $meth:ident, $T:ident) => {

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use std::ops::{Div, Mul, Add, Sub, Neg, Shl, Shr, BitXor, BitAnd, BitOr, Rem};
 use std::ffi::CString;
 use std::{u32, i32};
+use num_traits::{Zero, One};
 
 use ffi::*;
 
@@ -898,3 +899,19 @@ impl hash::Hash for Mpz {
         }
     }
 }
+
+impl Zero for Mpz {
+    fn zero() -> Self {
+        Mpz::zero()
+    }
+    fn is_zero(&self) -> bool {
+        self.is_zero()
+    }
+}
+
+impl One for Mpz {
+    fn one() -> Self {
+        Mpz::one()
+    }
+}
+


### PR DESCRIPTION
As far as I can tell the corresponding traits from std are deprecated in favour of the traits from `num`. This also matches with what is done in e.g. [ramp](https://github.com/Aatch/ramp/blob/master/src/int.rs#L35).