### PR TITLE
Implement From, not Into

### DIFF
--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -2,7 +2,7 @@ use super::mpz::{mpz_struct, Mpz, mpz_ptr, mpz_srcptr};
 use super::mpf::{Mpf, mpf_srcptr};
 use ffi::*;
 use libc::{c_double, c_int, c_ulong};
-use std::convert::{From, Into};
+use std::convert::From;
 use std::mem::uninitialized;
 use std::fmt;
 use std::cmp::Ordering::{self, Greater, Less, Equal};
@@ -297,16 +297,28 @@ impl Neg for Mpq {
     }
 }
 
-impl Into<f64> for Mpq {
-    fn into(self) -> f64 {
+impl From<Mpq> for f64 {
+    fn from(other: Mpq) -> f64 {
+        f64::from(&other)
+    }
+}
+
+impl<'a> From<&'a Mpq> for f64 {
+    fn from(other: &Mpq) -> f64 {
         unsafe {
-            __gmpq_get_d(&self.mpq) as f64
+            __gmpq_get_d(&other.mpq) as f64
         }
     }
 }
 
 impl From<Mpz> for Mpq {
     fn from(other: Mpz) -> Mpq {
+        Mpq::from(&other)
+    }
+}
+
+impl<'a> From<&'a Mpz> for Mpq {
+    fn from(other: &Mpz) -> Mpq {
         let mut res = Mpq::new();
         res.set_z(&other);
         res

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -297,18 +297,6 @@ impl Neg for Mpq {
     }
 }
 
-impl Into<Option<i64>> for Mpq {
-    fn into(self) -> Option<i64> {
-        panic!("not implemented")
-    }
-}
-
-impl Into<Option<u64>> for Mpq {
-    fn into(self) -> Option<u64> {
-        panic!("not implemented")
-    }
-}
-
 impl Into<f64> for Mpq {
     fn into(self) -> f64 {
         unsafe {

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -1,6 +1,6 @@
 use libc::{c_char, c_int, c_long, c_ulong, c_void, c_double, size_t};
 use super::rand::gmp_randstate_t;
-use std::convert::{From, Into};
+use std::convert::From;
 use std::mem::{uninitialized,size_of};
 use std::{fmt, hash};
 use std::cmp::Ordering::{self, Greater, Less, Equal};
@@ -706,28 +706,28 @@ impl Not for Mpz {
 }
 
 // Similarly to mpz_export, this does not preserve the sign of the input.
-impl<'b> Into<Vec<u8>> for &'b Mpz {
-    fn into(self) -> Vec<u8> {
+impl<'b> From<&'b Mpz> for Vec<u8> {
+    fn from(other: &Mpz) -> Vec<u8> {
         unsafe {
             let bit_size = size_of::<u8>() * 8;
-            let size = (__gmpz_sizeinbase(&self.mpz, 2) + bit_size - 1) / bit_size;
+            let size = (__gmpz_sizeinbase(&other.mpz, 2) + bit_size - 1) / bit_size;
             let mut result: Vec<u8> = vec!(0; size);
-            __gmpz_export(result.as_mut_ptr() as *mut c_void, 0 as *mut size_t, 1, size_of::<u8>() as size_t, 0, 0, &self.mpz);
+            __gmpz_export(result.as_mut_ptr() as *mut c_void, 0 as *mut size_t, 1, size_of::<u8>() as size_t, 0, 0, &other.mpz);
             result
         }
     }
 }
 
-impl<'b> Into<Option<i64>> for &'b Mpz {
-    fn into(self) -> Option<i64> {
+impl<'b> From<&'b Mpz> for Option<i64> {
+    fn from(other: &Mpz) -> Option<i64> {
         unsafe {
-            let negative = self.mpz._mp_size < 0;
+            let negative = other.mpz._mp_size < 0;
             let mut to_export = Mpz::new();
 
             if negative {
-                __gmpz_com(&mut to_export.mpz, &self.mpz);
+                __gmpz_com(&mut to_export.mpz, &other.mpz);
             } else {
-                __gmpz_set(&mut to_export.mpz, &self.mpz);
+                __gmpz_set(&mut to_export.mpz, &other.mpz);
             }
 
             if __gmpz_sizeinbase(&to_export.mpz, 2) <= 63 {
@@ -745,12 +745,12 @@ impl<'b> Into<Option<i64>> for &'b Mpz {
     }
 }
 
-impl<'b> Into<Option<u64>> for &'b Mpz {
-    fn into(self) -> Option<u64> {
+impl<'b> From<&'b Mpz> for Option<u64> {
+    fn from(other: &Mpz) -> Option<u64> {
         unsafe {
-            if __gmpz_sizeinbase(&self.mpz, 2) <= 64 && self.mpz._mp_size >= 0 {
+            if __gmpz_sizeinbase(&other.mpz, 2) <= 64 && other.mpz._mp_size >= 0 {
                 let mut result : u64 = 0;
-                __gmpz_export(&mut result as *mut u64 as *mut c_void, 0 as *mut size_t, -1, size_of::<u64>() as size_t, 0, 0, &self.mpz);
+                __gmpz_export(&mut result as *mut u64 as *mut c_void, 0 as *mut size_t, -1, size_of::<u64>() as size_t, 0, 0, &other.mpz);
                 Some(result)
             } else {
                 None
@@ -759,10 +759,10 @@ impl<'b> Into<Option<u64>> for &'b Mpz {
     }
 }
 
-impl<'a> Into<f64> for &'a Mpz {
-    fn into(self) -> f64 {
+impl<'a> From<&'a Mpz> for f64 {
+    fn from(other: &Mpz) -> f64 {
         unsafe {
-            __gmpz_get_d(&self.mpz) as f64
+            __gmpz_get_d(&other.mpz) as f64
         }
     }
 }


### PR DESCRIPTION
https://doc.rust-lang.org/std/convert/trait.Into.html: “Library authors should not directly implement this trait, but should prefer implementing the From trait, which offers greater flexibility and provides an equivalent Into implementation for free, thanks to a blanket implementation in the standard library.”