### PR TITLE
Mpz, Mpq, Mpf, RandState: mark Sync

### DIFF
--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -60,6 +60,7 @@ pub struct Mpf {
 }
 
 unsafe impl Send for Mpf { }
+unsafe impl Sync for Mpf { }
 
 impl Drop for Mpf {
     fn drop(&mut self) { unsafe { __gmpf_clear(&mut self.mpf) } }

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -54,6 +54,7 @@ pub struct Mpq {
 }
 
 unsafe impl Send for Mpq { }
+unsafe impl Sync for Mpq { }
 
 impl Drop for Mpq {
     fn drop(&mut self) { unsafe { __gmpq_clear(&mut self.mpq) } }

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -99,6 +99,7 @@ pub struct Mpz {
 }
 
 unsafe impl Send for Mpz { }
+unsafe impl Sync for Mpz { }
 
 impl Drop for Mpz {
     fn drop(&mut self) { unsafe { __gmpz_clear(&mut self.mpz) } }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -29,6 +29,9 @@ pub struct RandState {
     state: gmp_randstate_struct,
 }
 
+unsafe impl Send for RandState { }
+unsafe impl Sync for RandState { }
+
 impl Drop for RandState {
     fn drop(&mut self) {
         unsafe { __gmp_randclear(&mut self.state) }


### PR DESCRIPTION
GMP guarantees that it’s safe for two threads to read from the same GMP variable simultaneously (https://gmplib.org/manual/Reentrancy.html), so the types should be marked `Sync`.  The Rust type system still protects against read/write and write/write races.