### PR TITLE
support for powm_sec

### DIFF
--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -73,6 +73,7 @@ extern "C" {
     fn __gmpz_pow_ui(rop: mpz_ptr, base: mpz_srcptr, exp: c_ulong);
     fn __gmpz_ui_pow_ui(rop: mpz_ptr, base: c_ulong, exp: c_ulong);
     fn __gmpz_powm(rop: mpz_ptr, base: mpz_srcptr, exp: mpz_srcptr, modulo: mpz_srcptr);
+    fn __gmpz_powm_sec(rop: mpz_ptr, base: mpz_srcptr, exp: mpz_srcptr, modulo: mpz_srcptr);
     fn __gmpz_hamdist(op1: mpz_srcptr, op2: mpz_srcptr) -> mp_bitcnt_t;
     fn __gmpz_setbit(rop: mpz_ptr, bit_index: mp_bitcnt_t);
     fn __gmpz_clrbit(rop: mpz_ptr, bit_index: mp_bitcnt_t);
@@ -331,6 +332,14 @@ impl Mpz {
         unsafe {
             let mut res = Mpz::new();
             __gmpz_powm(&mut res.mpz, &self.mpz, &exp.mpz, &modulus.mpz);
+            res
+        }
+    }
+
+    pub fn powm_sec(&self, exp: &Mpz, modulus: &Mpz) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+            __gmpz_powm_sec(&mut res.mpz, &self.mpz, &exp.mpz, &modulus.mpz);
             res
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -299,6 +299,15 @@ mod mpz {
     }
 
     #[test]
+    fn test_powm_sec() {
+        let a: Mpz = From::<i64>::from(13);
+        let b: Mpz = From::<i64>::from(7);
+        let p: Mpz = From::<i64>::from(19);
+        let c: Mpz = From::<i64>::from(10);
+        assert!(a.powm_sec(&b, &p) == c);
+    }
+
+    #[test]
     fn test_popcount() {
         Mpz::from_str_radix("1010010011", 2).unwrap().popcount() == 5;
     }


### PR DESCRIPTION
When using GMP for cryptographic applications it is often desirable to have functions resilient to timing attacks, such as `powm_sec` for integer exponentiation (https://gmplib.org/manual/Integer-Exponentiation.html#Integer-Exponentiation). This PR exposes this function.