### PR TITLE
added mpz, mpq, and mpf sign

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod mpz;
 pub mod mpq;
 pub mod mpf;
 pub mod rand;
+pub mod sign;
 
 #[cfg(test)]
 mod test;

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -8,6 +8,7 @@ use std::string::String;
 use super::mpz::mp_bitcnt_t;
 use super::mpz::{Mpz, mpz_srcptr};
 use super::mpq::{Mpq, mpq_srcptr};
+use super::sign::Sign;
 use num_traits::{Zero, One};
 
 type mp_exp_t = c_long;
@@ -179,6 +180,17 @@ impl Mpf {
             }
         }
         retval
+    }
+
+    pub fn sign(&self) -> Sign {
+        let size = self.mpf._mp_size;
+        if size == 0 {
+            Sign::Zero
+        } else if size > 0 {
+            Sign::Positive
+        } else {
+            Sign::Negative
+        }
     }
 }
 

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -1,5 +1,6 @@
 use super::mpz::{mpz_struct, Mpz, mpz_ptr, mpz_srcptr};
 use super::mpf::{Mpf, mpf_srcptr};
+use super::sign::Sign;
 use ffi::*;
 use libc::{c_char, c_double, c_int, c_ulong};
 use std::ffi::CString;
@@ -172,6 +173,10 @@ impl Mpq {
             __gmpz_cdiv_q(res.inner_mut(), &self.mpq._mp_num, &self.mpq._mp_den);
         }
         res
+    }
+
+    pub fn sign(&self) -> Sign {
+        self.get_num().sign()
     }
 
     pub fn one() -> Mpq {

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -1,5 +1,6 @@
 use libc::{c_char, c_int, c_long, c_ulong, c_void, c_double, size_t};
 use super::rand::gmp_randstate_t;
+use super::sign::Sign;
 use std::convert::From;
 use std::mem::{uninitialized,size_of};
 use std::{fmt, hash};
@@ -422,6 +423,17 @@ impl Mpz {
     pub fn millerrabin(&self, reps: i32) -> i32 {
         unsafe {
             __gmpz_millerrabin(&self.mpz, reps as c_int)
+        }
+    }
+
+    pub fn sign(&self) -> Sign {
+        let size = self.mpz._mp_size;
+        if size == 0 {
+            Sign::Zero
+        } else if size > 0 {
+            Sign::Positive
+        } else {
+            Sign::Negative
         }
     }
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,0 +1,7 @@
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Debug)]
+pub enum Sign {
+    Negative,
+    Zero,
+    Positive,
+}
+

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,6 +16,7 @@ fn test_limb_size() {
 mod mpz {
     use super::super::mpz::Mpz;
     use super::super::mpz::ProbabPrimeResult;
+    use super::super::sign::Sign;
     use std::str::FromStr;
     use std::convert::{From, Into};
     use std::{i64, u64};
@@ -556,6 +557,17 @@ mod mpz {
         assert_eq!(Into::<Option<i64>>::into(&max_i64), Some(i64::MAX));
         assert_eq!(Into::<Option<i64>>::into(&(&max_i64 + &one)), None);
     }
+
+    #[test]
+    fn test_sign() {
+        let zero: Mpz = From::<i64>::from(0);
+        let five: Mpz = From::<i64>::from(5);
+        let minus_five: Mpz = From::<i64>::from(-5);
+
+        assert_eq!(zero.sign(), Sign::Zero);
+        assert_eq!(five.sign(), Sign::Positive);
+        assert_eq!(minus_five.sign(), Sign::Negative);
+    }
 }
 
 mod rand {
@@ -581,6 +593,7 @@ mod mpq {
     use std::u64;
     use super::super::mpq::Mpq;
     use super::super::mpz::Mpz;
+    use super::super::sign::Sign;
 
     #[test]
     fn test_one() {
@@ -636,15 +649,40 @@ mod mpq {
         let minus_half = -half;
         assert_eq!(minus_half.ceil(), Mpz::from(0));
     }
+
+    #[test]
+    fn test_sign() {
+        let zero: Mpq = From::<i64>::from(0);
+        let five: Mpq = From::<i64>::from(5);
+        let minus_five: Mpq = From::<i64>::from(-5);
+
+        assert_eq!(zero.sign(), Sign::Zero);
+        assert_eq!(five.sign(), Sign::Positive);
+        assert_eq!(minus_five.sign(), Sign::Negative);
+    }
 }
 
 mod mpf {
     use super::super::mpf::Mpf;
+    use super::super::sign::Sign;
 
     #[test]
     #[should_panic]
     fn test_div_zero() {
         let x = Mpf::new(0);
         &x / &x;
+    }
+
+    #[test]
+    fn test_sign() {
+        let zero = Mpf::zero();
+        let mut five = Mpf::zero();
+        Mpf::set_from_si(&mut five, 5);
+        let mut minus_five = Mpf::zero();
+        Mpf::set_from_si(&mut minus_five, -5);
+
+        assert_eq!(zero.sign(), Sign::Zero);
+        assert_eq!(five.sign(), Sign::Positive);
+        assert_eq!(minus_five.sign(), Sign::Negative);
     }
 }


### PR DESCRIPTION
Added functions to get the sign of Mpz, Mpq, and Mpf. Although mp{z,q,f}_sgn functions appear to exist in the original C++ API, they are actually macros and cannot be used here.

Old way of getting sign:
```
match n.cmp(&Mpz::zero()) { // allocation :(
    Ordering::Less => ...,
    Ordering::Equal => ...,
    Ordering::Greater => ...,
}
```
New way:
```
match n.sign() {
    Sign::Negative => ...,
    Sign::Zero => ...,
    Sign::Positive => ...,
}
```
I'm new to Rust, so any feedback is appreciated!