### PR TITLE
Make `Mpq::ratio` and `Mpq::from_str_radix` safe

### DIFF
--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -89,12 +89,6 @@ impl Mpq {
         }
     }
 
-    pub fn canonicalize(&mut self) {
-        unsafe {
-            __gmpq_canonicalize(&mut self.mpq);
-        }
-    }
-
     pub fn from_str_radix(s: &str, base: u8) -> Result<Mpq, ParseMpqError> {
         let s = CString::new(s).map_err(|_| ParseMpqError { _priv: () })?;
         let mut res = Mpq::new();

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -83,6 +83,8 @@ impl Mpq {
             let mut res = Mpq::new();
             __gmpq_set_num(&mut res.mpq, num.inner());
             __gmpq_set_den(&mut res.mpq, den.inner());
+            // Not canonicalizing is unsafe
+            __gmpq_canonicalize(&mut res.mpq);
             res
         }
     }
@@ -99,7 +101,10 @@ impl Mpq {
         unsafe {
             assert!(base == 0 || (base >= 2 && base <= 62));
             let r = __gmpq_set_str(&mut res.mpq, s.as_ptr(), base as c_int);
+
             if r == 0 {
+                // Not canonicalizing is unsafe
+                __gmpq_canonicalize(&mut res.mpq);
                 Ok(res)
             } else {
                 Err(ParseMpqError { _priv: () })

--- a/src/test.rs
+++ b/src/test.rs
@@ -660,6 +660,32 @@ mod mpq {
         assert_eq!(five.sign(), Sign::Positive);
         assert_eq!(minus_five.sign(), Sign::Negative);
     }
+
+    #[test]
+    fn test_ratio() {
+        let zero: Mpz = From::<i64>::from(0);
+        let one: Mpz = From::<i64>::from(1);
+        let minus_one = -&one;
+        let two = &one + &one;
+        let four = &two + &two;
+
+        assert_eq!(Mpq::ratio(&one, &minus_one), Mpq::ratio(&minus_one, &one));
+        assert_eq!(Mpq::ratio(&zero, &one), Mpq::ratio(&zero, &minus_one));
+        assert_eq!(Mpq::ratio(&zero, &one), Mpq::ratio(&zero, &two));
+        assert_eq!(Mpq::ratio(&two, &four), Mpq::ratio(&one, &two));
+    }
+
+    #[test]
+    fn test_from_str_radix() {
+        let zero: Mpz = From::<i64>::from(0);
+        let one: Mpz = From::<i64>::from(1);
+        let minus_one = -&one;
+        let two = &one + &one;
+
+        assert_eq!(Mpq::from_str_radix("1/-1", 10).unwrap(), Mpq::ratio(&minus_one, &one));
+        assert_eq!(Mpq::from_str_radix("0/2", 10).unwrap(), Mpq::ratio(&zero, &one));
+        assert_eq!(Mpq::from_str_radix("2/4", 10).unwrap(), Mpq::ratio(&one, &two));
+    }
 }
 
 mod mpf {

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,7 +10,8 @@ extern "C" {
 #[test]
 fn test_limb_size() {
     // We are assuming that the limb size is the same as the pointer size.
-    assert_eq!(std::mem::size_of::<mp_limb_t>() * 8, __gmp_bits_per_limb as usize);
+    assert_eq!(std::mem::size_of::<mp_limb_t>() * 8,
+               unsafe { __gmp_bits_per_limb as usize });
 }
 
 mod mpz {
@@ -21,7 +22,8 @@ mod mpz {
     use std::convert::{From, Into};
     use std::{i64, u64};
 
-    use std::hash::{Hash, Hasher, SipHasher};
+    use std::hash::{Hash, Hasher};
+    use std::collections::hash_map::DefaultHasher;
 
     #[test]
     fn test_set() {
@@ -472,7 +474,7 @@ mod mpz {
         let two = &one + &one;
 
         let hash = |x : &Mpz| {
-            let mut hasher = SipHasher::new();
+            let mut hasher = DefaultHasher::new();
             x.hash(&mut hasher);
             hasher.finish()
         };
@@ -490,7 +492,7 @@ mod mpz {
         let one: Mpz = From::<i64>::from(1);
 
         let hash = |x : &Mpz| {
-            let mut hasher = SipHasher::new();
+            let mut hasher = DefaultHasher::new();
             x.hash(&mut hasher);
             hasher.finish()
         };


### PR DESCRIPTION
Also fix some warnings and remove the now useless `Mpq::canonicalize`.