### PR TITLE
Mpf get str fixups

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,7 +1,38 @@
 use mpz::*;
+use std::{mem, slice, str};
+use libc::{c_char, strlen};
+
+type AllocFunc = extern "C" fn(usize) -> *mut c_char;
+type ReallocFunc = extern "C" fn(*mut c_char, usize, usize) -> *mut c_char;
+type FreeFunc = extern "C" fn(*mut c_char, usize);
 
 #[link(name = "gmp")]
 extern "C" {
     pub fn __gmpz_fdiv_q(q: mpz_ptr, n: mpz_srcptr, d: mpz_srcptr);
     pub fn __gmpz_cdiv_q(q: mpz_ptr, n: mpz_srcptr, d: mpz_srcptr);
+    pub fn __gmp_get_memory_functions(alloc: *mut AllocFunc, relloc: *mut ReallocFunc, free: *mut FreeFunc);
+}
+
+pub struct GString(*mut u8, usize);
+
+impl GString {
+    pub unsafe fn from_raw(raw: *mut c_char) -> GString {
+        GString(mem::transmute(raw), strlen(raw) as usize + 1)
+    }
+
+    pub fn to_str(&self) -> Result<&str, str::Utf8Error> {
+        let bytes: &[u8] = unsafe { slice::from_raw_parts(self.0, self.1) };
+        str::from_utf8(&bytes[..bytes.len() - 1])
+    }
+}
+
+impl Drop for GString {
+    fn drop(&mut self) {
+        use std::ptr::null_mut;
+        unsafe {
+            let mut free_func: FreeFunc = mem::uninitialized();
+            __gmp_get_memory_functions(null_mut(), null_mut(), mem::transmute(&mut free_func));
+            free_func(mem::transmute(self.0), self.1);
+        }
+    }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -17,7 +17,7 @@ pub struct GString(*mut u8, usize);
 
 impl GString {
     pub unsafe fn from_raw(raw: *mut c_char) -> GString {
-        GString(mem::transmute(raw), strlen(raw) as usize + 1)
+        GString(raw as *mut u8, strlen(raw) as usize + 1)
     }
 
     pub fn to_str(&self) -> Result<&str, str::Utf8Error> {
@@ -31,8 +31,8 @@ impl Drop for GString {
         use std::ptr::null_mut;
         unsafe {
             let mut free_func: FreeFunc = mem::uninitialized();
-            __gmp_get_memory_functions(null_mut(), null_mut(), mem::transmute(&mut free_func));
-            free_func(mem::transmute(self.0), self.1);
+            __gmp_get_memory_functions(null_mut(), null_mut(), &mut free_func);
+            free_func(self.0 as *mut c_char, self.1);
         }
     }
 }

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -38,7 +38,7 @@ extern "C" {
 
     fn __gmpf_set_str(rop: mpf_ptr, str: *const c_char, base: c_int);
     fn __gmpf_set_si(rop: mpf_ptr, op: c_long);
-    fn __gmpf_get_str(str: *const c_char, expptr: *const mp_exp_t, base: i32, n_digits: i32, op: mpf_srcptr) -> *mut c_char;
+    fn __gmpf_get_str(str: *mut c_char, expptr: *const mp_exp_t, base: i32, n_digits: i32, op: mpf_srcptr) -> *mut c_char;
 
     fn __gmpf_cmp(op1: mpf_srcptr, op2: mpf_srcptr) -> c_int;
     fn __gmpf_cmp_d(op1: mpf_srcptr, op2: c_double) -> c_int;

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -1,5 +1,5 @@
 use libc::{c_double, c_int, c_long, c_ulong, c_void,c_char};
-use std::mem::{transmute, uninitialized};
+use std::mem::uninitialized;
 use std::cmp;
 use std::cmp::Ordering::{self, Greater, Less, Equal};
 use std::ops::{Div, DivAssign, Mul, MulAssign, Add, AddAssign, Sub, SubAssign, Neg};
@@ -134,7 +134,7 @@ impl Mpf {
             let bytes = unsafe {
                 // n_digits + 2 from mpf/get_str.c.
                 let mut bytes: Vec<u8> = vec![0; n_digits as usize + 2];
-                let c_str: *mut c_char = transmute(bytes.as_mut_ptr());
+                let c_str: *mut c_char = bytes.as_mut_ptr() as *mut c_char;
                 __gmpf_get_str(c_str, exp, base, n_digits, &self.mpf);
                 bytes
             };

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -131,9 +131,9 @@ impl Mpf {
                 GString::from_raw(p).to_str().unwrap().to_string()
             }
         } else {
-            // From mpf/get_str.c.
             let bytes = unsafe {
-                let mut bytes: Vec<u8> = uninitialized();
+                // n_digits + 2 from mpf/get_str.c.
+                let mut bytes: Vec<u8> = vec![0; n_digits as usize + 2];
                 let c_str: *mut c_char = transmute(bytes.as_mut_ptr());
                 __gmpf_get_str(c_str, exp, base, n_digits, &self.mpf);
                 bytes

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -37,7 +37,7 @@ extern "C" {
 
     fn __gmpf_set_str(rop: mpf_ptr, str: *const c_char, base: c_int);
     fn __gmpf_set_si(rop: mpf_ptr, op: c_long);
-    fn __gmpf_get_str(str: *const c_char, expptr: *const mp_exp_t, base: i32, n_digits: i32, op: mpf_ptr) -> *mut c_char;
+    fn __gmpf_get_str(str: *const c_char, expptr: *const mp_exp_t, base: i32, n_digits: i32, op: mpf_srcptr) -> *mut c_char;
 
     fn __gmpf_cmp(op1: mpf_srcptr, op2: mpf_srcptr) -> c_int;
     fn __gmpf_cmp_d(op1: mpf_srcptr, op2: c_double) -> c_int;

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -121,12 +121,12 @@ impl Mpf {
     }
 
     pub fn get_str(&self, n_digits: i32, base: i32, exp: &mut c_long) -> String {
-        use std::ptr::null;
+        use std::ptr::null_mut;
         if n_digits == 0 {
             // Maximal significant digits requested. Let GMP compute the length
             // and allocate the space required.
             unsafe {
-                let p = __gmpf_get_str(null(), exp, base, n_digits, &self.mpf);
+                let p = __gmpf_get_str(null_mut(), exp, base, n_digits, &self.mpf);
                 // De-allocates the GMP string on drop.
                 GString::from_raw(p).to_str().unwrap().to_string()
             }

--- a/src/test.rs
+++ b/src/test.rs
@@ -713,4 +713,16 @@ mod mpf {
         assert_eq!(five.sign(), Sign::Positive);
         assert_eq!(minus_five.sign(), Sign::Negative);
     }
+
+    #[test]
+    fn test_get_str() {
+        use libc::c_long;
+        let mut tmp = 0 as c_long;
+        let mut pi: Mpf = Mpf::zero();
+        assert_eq!(pi.get_str(4, 10, &mut tmp), "");
+        pi.set_from_str("3.141592653589", 10);
+
+        assert_eq!(&pi.get_str(4, 10, &mut tmp), "3142");
+        assert_eq!((-&pi).get_str(4, 10, &mut tmp), "-3142");
+    }
 }


### PR DESCRIPTION
bug was introduced in 877104f58239fd19a4f3f5aed13bdd677c65f28b.

the intent here is to allocate enough space for gmpf_get_str to plop a string. if all digits are requested (n_digits == 0), we defer to gmpf_get_str itself to figure out how much space is needed (because the limb nonsense is too tedious to deal with) by passing nullptr to the first argument, as documented in the manual:

> If str is NULL, the result string is allocated using the current allocation function (see Custom Allocation). The block will be strlen(str)+1 bytes, that being exactly enough for the string and null-terminator.

if the number of digits requested is known (non-zero n_digits), then simply allocate a correctly sized cstring (unlike 877104f58239fd19a4f3f5aed13bdd677c65f28b, which allocates a 0-byte string).

to avoid memory leaks from repeated get_str(n_digits=0) calls, a wrapper is used to de-allocate on drop the gmp-allocated string.

with this patch, #24 passes.