### PR TITLE
Adding serde support feature for Mpz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 Cargo.lock
 *.swp
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ name = "gmp"
 default = []
 
 # Feature for enabling de/serialization of Mpz
-
 serde_support = ["serde"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ keywords = [ "gmp", "multi", "precision", "arithmetic", "bignum" ]
 [lib]
 name = "gmp"
 
+[features]
+default = []
+
+# Feature for enabling de/serialization of Mpz
+serde_support = ["serde", "serde_derive", "serde_json"]
+
 [dependencies]
 libc = "~0.2"
 num-traits = "0.1"
+
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_support = ["serde", "serde_derive", "serde_json"]
 
 [dependencies]
 libc = "~0.2"
-num-traits = "0.1"
+num-traits = "0.2"
 
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "rust-gmp"
 version = "0.5.1"
 authors = [ "thestinger <danielmicay@gmail.com>", "Bartłomiej Kamiński <fizyk20@gmail.com>" ]
 description = "Rust bindings for GMP"
-repository = "https://github.com/fizyk20/rust-gmp"
-documentation = "https://docs.rs/rust-gmp"
+repository = "https://github.com/ZenGo-X/rust-gmp"
+documentation = "https://docs.rs/rust-gmp-kzen"
 license = "MIT"
 keywords = [ "gmp", "multi", "precision", "arithmetic", "bignum" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-gmp-kzen"
+name = "rust-gmp"
 version = "0.5.1"
 authors = [ "thestinger <danielmicay@gmail.com>", "Bartłomiej Kamiński <fizyk20@gmail.com>" ]
 description = "Rust bindings for GMP"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ name = "gmp"
 default = []
 
 # Feature for enabling de/serialization of Mpz
-serde_support = ["serde", "serde_derive", "serde_json"]
+serde_support = ["serde"]
 
 [dependencies]
 libc = "~0.2"
 num-traits = "0.2"
 
-serde = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
-serde_json = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = { version = "1.0" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-gmp"
-version = "0.5.0"
+version = "0.5.1"
 authors = [ "thestinger <danielmicay@gmail.com>", "Bartłomiej Kamiński <fizyk20@gmail.com>" ]
 description = "Rust bindings for GMP"
 repository = "https://github.com/fizyk20/rust-gmp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-gmp"
+name = "rust-gmp-kzen"
 version = "0.5.1"
 authors = [ "thestinger <danielmicay@gmail.com>", "Bartłomiej Kamiński <fizyk20@gmail.com>" ]
 description = "Rust bindings for GMP"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,9 @@
 extern crate libc;
 extern crate num_traits;
 
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 extern crate serde;
-
-#[cfg(feature="serde_support")]
-extern crate serde_derive;
-
-#[cfg(feature="serde_support")]
+#[cfg(all(test, feature="serde"))]
 extern crate serde_json;
 
 mod ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,15 @@
 extern crate libc;
 extern crate num_traits;
 
+#[cfg(feature="serde_support")]
+extern crate serde;
+
+#[cfg(feature="serde_support")]
+extern crate serde_derive;
+
+#[cfg(feature="serde_support")]
+extern crate serde_json;
+
 mod ffi;
 pub mod mpz;
 pub mod mpq;

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -103,9 +103,18 @@ pub struct Mpz {
 
 unsafe impl Send for Mpz { }
 unsafe impl Sync for Mpz { }
-
+use std::sync::atomic;
 impl Drop for Mpz {
-    fn drop(&mut self) { unsafe { __gmpz_clear(&mut self.mpz) } }
+    fn drop(&mut self) {
+        println!("drop gmp");
+        unsafe {
+            std::ptr::write_volatile(self, Mpz::one());
+            __gmpz_clear(&mut self.mpz);
+        }
+
+        atomic::fence(atomic::Ordering::SeqCst);
+        atomic::compiler_fence(atomic::Ordering::SeqCst);
+    }
 }
 
 /// The result of running probab_prime

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -12,13 +12,13 @@ use std::ffi::CString;
 use std::{u32, i32};
 use num_traits::{Zero, One};
 
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 use serde::ser::{Serialize, Serializer};
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 use serde::de::{Visitor};
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 use serde::de;
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 use serde::{Deserialize, Deserializer};
 
 use ffi::*;
@@ -111,10 +111,10 @@ pub struct Mpz {
     mpz: mpz_struct,
 }
 
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 const HEX_RADIX : u8 = 16;
 
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 impl Serialize for Mpz {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -124,10 +124,10 @@ impl Serialize for Mpz {
     }
 }
 
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 struct MpzVisitor;
 
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 impl<'de> Deserialize<'de> for Mpz {
     fn deserialize<D>(deserializer: D) -> Result<Mpz, D::Error>
         where
@@ -137,7 +137,7 @@ impl<'de> Deserialize<'de> for Mpz {
     }
 }
 
-#[cfg(feature="serde_support")]
+#[cfg(feature="serde")]
 impl<'de> Visitor<'de> for MpzVisitor {
     type Value = Mpz;
 

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -37,6 +37,7 @@ extern "C" {
     fn __gmpz_clear(x: mpz_ptr);
     fn __gmpz_realloc2(x: mpz_ptr, n: mp_bitcnt_t);
     fn __gmpz_set(rop: mpz_ptr, op: mpz_srcptr);
+    fn __gmpz_set_ui(rop: mpz_ptr, op: c_ulong);
     fn __gmpz_set_str(rop: mpz_ptr, s: *const c_char, base: c_int) -> c_int;
     fn __gmpz_get_str(s: *mut c_char, base: c_int, op: mpz_srcptr) -> *mut c_char;
     fn __gmpz_get_ui(op: mpz_srcptr) -> c_ulong;
@@ -106,9 +107,8 @@ unsafe impl Sync for Mpz { }
 use std::sync::atomic;
 impl Drop for Mpz {
     fn drop(&mut self) {
-        println!("drop gmp");
         unsafe {
-            std::ptr::write_volatile(self, Mpz::one());
+            __gmpz_set_ui(&mut self.mpz, 0 as c_ulong);
             __gmpz_clear(&mut self.mpz);
         }
 

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -12,6 +12,15 @@ use std::ffi::CString;
 use std::{u32, i32};
 use num_traits::{Zero, One};
 
+#[cfg(feature="serde_support")]
+use serde::ser::{Serialize, Serializer};
+#[cfg(feature="serde_support")]
+use serde::de::{Visitor};
+#[cfg(feature="serde_support")]
+use serde::de;
+#[cfg(feature="serde_support")]
+use serde::{Deserialize, Deserializer};
+
 use ffi::*;
 
 #[repr(C)]
@@ -101,6 +110,45 @@ extern "C" {
 
 pub struct Mpz {
     mpz: mpz_struct,
+}
+
+#[cfg(feature="serde_support")]
+const HEX_RADIX : u8 = 16;
+
+#[cfg(feature="serde_support")]
+impl Serialize for Mpz {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        serializer.serialize_str(&self.to_str_radix(HEX_RADIX))
+    }
+}
+
+#[cfg(feature="serde_support")]
+struct MpzVisitor;
+
+#[cfg(feature="serde_support")]
+impl<'de> Deserialize<'de> for Mpz {
+    fn deserialize<D>(deserializer: D) -> Result<Mpz, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(MpzVisitor)
+    }
+}
+
+#[cfg(feature="serde_support")]
+impl<'de> Visitor<'de> for MpzVisitor {
+    type Value = Mpz;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("BigInt")
+    }
+
+    fn visit_str<E: de::Error>(self, s: &str) -> Result<Mpz, E> {
+       Ok(Mpz::from_str_radix(s, HEX_RADIX).expect("Failed in serde"))
+    }
 }
 
 unsafe impl Send for Mpz { }

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -171,7 +171,7 @@ impl Drop for Mpz {
                  *    Also I think we should be having something in the gmp library itself to do this kind of a thing.
                  *    The process for that is in flight. If that is accepted we can use that here.
                 */
-                std::ptr::write_volatile(dst.add(i as usize) as *mut c_int, 0 as c_int);
+                std::ptr::write_volatile(dst.add(i as usize) as *mut c_int, 0);
             }
             __gmpz_clear(&mut self.mpz);
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -25,6 +25,9 @@ mod mpz {
     use std::hash::{Hash, Hasher};
     use std::collections::hash_map::DefaultHasher;
 
+    #[cfg(feature="serde_support")]
+    use serde_json;
+
     #[test]
     fn test_set() {
         let mut x: Mpz = From::<i64>::from(1000);
@@ -569,6 +572,17 @@ mod mpz {
         assert_eq!(zero.sign(), Sign::Zero);
         assert_eq!(five.sign(), Sign::Positive);
         assert_eq!(minus_five.sign(), Sign::Negative);
+    }
+
+    #[cfg(feature="serde_support")]
+    #[test]
+    fn test_serde() {
+        let one: Mpz = From::<i64>::from(1);
+        assert_eq!(serde_json::to_string(&one).unwrap(), "\"1\"");
+
+        let s_one = "\"1\"";
+        let o_one : Mpz = serde_json::from_str(&s_one).unwrap();
+        assert_eq!(o_one, one);
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -25,7 +25,7 @@ mod mpz {
     use std::hash::{Hash, Hasher};
     use std::collections::hash_map::DefaultHasher;
 
-    #[cfg(feature="serde_support")]
+    #[cfg(feature="serde")]
     use serde_json;
 
     #[test]
@@ -574,7 +574,7 @@ mod mpz {
         assert_eq!(minus_five.sign(), Sign::Negative);
     }
 
-    #[cfg(feature="serde_support")]
+    #[cfg(feature="serde")]
     #[test]
     fn test_serde() {
         let one: Mpz = From::<i64>::from(1);


### PR DESCRIPTION
We needed serde for Mpz in one of our upper layer (dependency). Here is a PR if you are interested, I added it as a feature.

```
cargo build --features "serde_support"
cargo test --features "serde_support"
```

Thanks,