### PR TITLE
derive debug trait for 'ProbabPrimeResult'

### DIFF
--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -109,7 +109,7 @@ impl Drop for Mpz {
 }
 
 /// The result of running probab_prime
-#[derive(PartialEq)]
+#[derive(PartialEq,Debug)]
 pub enum ProbabPrimeResult {
     NotPrime,
     ProbablyPrime,


### PR DESCRIPTION
Maybe it would be more convenient to print the result of `fn probab_prime`