### PR TITLE
Add impl From<u128, u16, u8, usize, i128, i16, i8, isize> for Mpz

### DIFF
--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -845,179 +845,54 @@ impl<'a> From<&'a [u8]> for Mpz {
     }
 }
 
-impl From<u128> for Mpz {
-    fn from(other: u128) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-            __gmpz_import(&mut res.mpz, 1, -1, size_of::<u128>() as size_t, 0, 0,
-                          &other as *const u128 as *const c_void);
-            res
-        }
-    }
-}
-
-impl From<u64> for Mpz {
-    fn from(other: u64) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-            __gmpz_import(&mut res.mpz, 1, -1, size_of::<u64>() as size_t, 0, 0,
-                          &other as *const u64 as *const c_void);
-            res
-        }
-    }
-}
-
-impl From<u32> for Mpz {
-    fn from(other: u32) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-            __gmpz_import(&mut res.mpz, 1, -1, size_of::<u32>() as size_t, 0, 0,
-                          &other as *const u32 as *const c_void);
-            res
-        }
-    }
-}
-
-impl From<u16> for Mpz {
-    fn from(other: u16) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-            __gmpz_import(&mut res.mpz, 1, -1, size_of::<u16>() as size_t, 0, 0,
-                          &other as *const u16 as *const c_void);
-            res
-        }
-    }
-}
-
-impl From<u8> for Mpz {
-    fn from(other: u8) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-            __gmpz_import(&mut res.mpz, 1, -1, size_of::<u8>() as size_t, 0, 0,
-                          &other as *const u8 as *const c_void);
-            res
-        }
-    }
-}
-
-impl From<usize> for Mpz {
-    fn from(other: usize) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-            __gmpz_import(&mut res.mpz, 1, -1, size_of::<usize>() as size_t, 0, 0,
-                          &other as *const usize as *const c_void);
-            res
-        }
-    }
-}
-
-impl From<i128> for Mpz {
-    fn from(other: i128) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-
-            if other.is_negative() {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i128>() as size_t, 0, 0,
-                              &(other ^ -1i128) as *const i128 as *const c_void);
-                __gmpz_com(&mut res.mpz, &res.mpz);
-            } else {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i128>() as size_t, 0, 0,
-                              &other as *const i128 as *const c_void);
+macro_rules! impl_from_uint {
+    ($typ: ident) => {
+        impl From<$typ> for Mpz {
+            fn from(other: $typ) -> Mpz {
+                let mut res = Mpz::new();
+                unsafe {
+                    __gmpz_import(&mut res.mpz, 1, -1, size_of::<$typ>() as size_t, 0, 0,
+                                  &other as *const $typ as *const c_void);
+                }
+                res
             }
-            res
         }
     }
 }
+impl_from_uint!(u128);
+impl_from_uint!(u64);
+impl_from_uint!(u32);
+impl_from_uint!(u16);
+impl_from_uint!(u8);
+impl_from_uint!(usize);
 
-impl From<i64> for Mpz {
-    fn from(other: i64) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-
-            if other.is_negative() {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i64>() as size_t, 0, 0,
-                              &(other ^ -1i64) as *const i64 as *const c_void);
-                __gmpz_com(&mut res.mpz, &res.mpz);
-            } else {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i64>() as size_t, 0, 0,
-                              &other as *const i64 as *const c_void);
+macro_rules! impl_from_iint {
+    ($typ: ident) => {
+        impl From<$typ> for Mpz {
+            fn from(other: $typ) -> Mpz {
+                let mut res = Mpz::new();
+                unsafe {
+                    if other.is_negative() {
+                        __gmpz_import(&mut res.mpz, 1, -1, size_of::<$typ>() as size_t, 0, 0,
+                                      &(other ^ (-1 as $typ)) as *const $typ as *const c_void);
+                        __gmpz_com(&mut res.mpz, &res.mpz);
+                    } else {
+                        __gmpz_import(&mut res.mpz, 1, -1, size_of::<$typ>() as size_t, 0, 0,
+                                      &other as *const $typ as *const c_void);
+                    }
+                }
+                res
             }
-            res
         }
+
     }
 }
-
-impl From<i32> for Mpz {
-    fn from(other: i32) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-
-            if other.is_negative() {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i32>() as size_t, 0, 0,
-                              &(other ^ -1i32) as *const i32 as *const c_void);
-                __gmpz_com(&mut res.mpz, &res.mpz);
-            } else {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i32>() as size_t, 0, 0,
-                              &other as *const i32 as *const c_void);
-            }
-            res
-        }
-    }
-}
-
-impl From<i16> for Mpz {
-    fn from(other: i16) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-
-            if other.is_negative() {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i16>() as size_t, 0, 0,
-                              &(other ^ -1i16) as *const i16 as *const c_void);
-                __gmpz_com(&mut res.mpz, &res.mpz);
-            } else {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i16>() as size_t, 0, 0,
-                              &other as *const i16 as *const c_void);
-            }
-            res
-        }
-    }
-}
-
-impl From<i8> for Mpz {
-    fn from(other: i8) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-
-            if other.is_negative() {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i8>() as size_t, 0, 0,
-                              &(other ^ -1i8) as *const i8 as *const c_void);
-                __gmpz_com(&mut res.mpz, &res.mpz);
-            } else {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i8>() as size_t, 0, 0,
-                              &other as *const i8 as *const c_void);
-            }
-            res
-        }
-    }
-}
-
-impl From<isize> for Mpz {
-    fn from(other: isize) -> Mpz {
-        unsafe {
-            let mut res = Mpz::new();
-
-            if other.is_negative() {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<isize>() as size_t, 0, 0,
-                              &(other ^ -1isize) as *const isize as *const c_void);
-                __gmpz_com(&mut res.mpz, &res.mpz);
-            } else {
-                __gmpz_import(&mut res.mpz, 1, -1, size_of::<isize>() as size_t, 0, 0,
-                              &other as *const isize as *const c_void);
-            }
-            res
-        }
-    }
-}
+impl_from_iint!(i128);
+impl_from_iint!(i64);
+impl_from_iint!(i32);
+impl_from_iint!(i16);
+impl_from_iint!(i8);
+impl_from_iint!(isize);
 
 impl_oper!(BitAnd, bitand, BitAndAssign, bitand_assign, __gmpz_and);
 impl_oper!(BitOr, bitor, BitOrAssign, bitor_assign, __gmpz_ior);

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -845,6 +845,17 @@ impl<'a> From<&'a [u8]> for Mpz {
     }
 }
 
+impl From<u128> for Mpz {
+    fn from(other: u128) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+            __gmpz_import(&mut res.mpz, 1, -1, size_of::<u128>() as size_t, 0, 0,
+                          &other as *const u128 as *const c_void);
+            res
+        }
+    }
+}
+
 impl From<u64> for Mpz {
     fn from(other: u64) -> Mpz {
         unsafe {
@@ -862,6 +873,57 @@ impl From<u32> for Mpz {
             let mut res = Mpz::new();
             __gmpz_import(&mut res.mpz, 1, -1, size_of::<u32>() as size_t, 0, 0,
                           &other as *const u32 as *const c_void);
+            res
+        }
+    }
+}
+
+impl From<u16> for Mpz {
+    fn from(other: u16) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+            __gmpz_import(&mut res.mpz, 1, -1, size_of::<u16>() as size_t, 0, 0,
+                          &other as *const u16 as *const c_void);
+            res
+        }
+    }
+}
+
+impl From<u8> for Mpz {
+    fn from(other: u8) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+            __gmpz_import(&mut res.mpz, 1, -1, size_of::<u8>() as size_t, 0, 0,
+                          &other as *const u8 as *const c_void);
+            res
+        }
+    }
+}
+
+impl From<usize> for Mpz {
+    fn from(other: usize) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+            __gmpz_import(&mut res.mpz, 1, -1, size_of::<usize>() as size_t, 0, 0,
+                          &other as *const usize as *const c_void);
+            res
+        }
+    }
+}
+
+impl From<i128> for Mpz {
+    fn from(other: i128) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+
+            if other.is_negative() {
+                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i128>() as size_t, 0, 0,
+                              &(other ^ -1i128) as *const i128 as *const c_void);
+                __gmpz_com(&mut res.mpz, &res.mpz);
+            } else {
+                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i128>() as size_t, 0, 0,
+                              &other as *const i128 as *const c_void);
+            }
             res
         }
     }
@@ -897,6 +959,60 @@ impl From<i32> for Mpz {
             } else {
                 __gmpz_import(&mut res.mpz, 1, -1, size_of::<i32>() as size_t, 0, 0,
                               &other as *const i32 as *const c_void);
+            }
+            res
+        }
+    }
+}
+
+impl From<i16> for Mpz {
+    fn from(other: i16) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+
+            if other.is_negative() {
+                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i16>() as size_t, 0, 0,
+                              &(other ^ -1i16) as *const i16 as *const c_void);
+                __gmpz_com(&mut res.mpz, &res.mpz);
+            } else {
+                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i16>() as size_t, 0, 0,
+                              &other as *const i16 as *const c_void);
+            }
+            res
+        }
+    }
+}
+
+impl From<i8> for Mpz {
+    fn from(other: i8) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+
+            if other.is_negative() {
+                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i8>() as size_t, 0, 0,
+                              &(other ^ -1i8) as *const i8 as *const c_void);
+                __gmpz_com(&mut res.mpz, &res.mpz);
+            } else {
+                __gmpz_import(&mut res.mpz, 1, -1, size_of::<i8>() as size_t, 0, 0,
+                              &other as *const i8 as *const c_void);
+            }
+            res
+        }
+    }
+}
+
+impl From<isize> for Mpz {
+    fn from(other: isize) -> Mpz {
+        unsafe {
+            let mut res = Mpz::new();
+
+            if other.is_negative() {
+                __gmpz_import(&mut res.mpz, 1, -1, size_of::<isize>() as size_t, 0, 0,
+                              &(other ^ -1isize) as *const isize as *const c_void);
+                __gmpz_com(&mut res.mpz, &res.mpz);
+            } else {
+                __gmpz_import(&mut res.mpz, 1, -1, size_of::<isize>() as size_t, 0, 0,
+                              &other as *const isize as *const c_void);
             }
             res
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -186,9 +186,35 @@ mod mpz {
 
     #[test]
     fn test_from_int() {
-        let x: Mpz = From::<i64>::from(150);
-        assert!(x.to_string() == "150".to_string());
-        assert!(x == FromStr::from_str("150").unwrap());
+        fn tst<T>(x: T, expected: &str)
+        where
+            Mpz: From<T>,
+        {
+            let x: Mpz = Mpz::from(x);
+            assert_eq!(x.to_string(), expected);
+            assert_eq!(x, FromStr::from_str(expected).unwrap());
+        }
+
+        tst(150_u8, "150");
+        tst(150_u16, "150");
+        tst(150_u32, "150");
+        tst(150_u64, "150");
+        tst(150_u128, "150");
+        tst(150_usize, "150");
+
+        tst(75_i8, "75");
+        tst(150_i16, "150");
+        tst(150_i32, "150");
+        tst(150_i64, "150");
+        tst(150_i128, "150");
+        tst(150_isize, "150");
+
+        tst(-75_i8, "-75");
+        tst(-150_i16, "-150");
+        tst(-150_i32, "-150");
+        tst(-150_i64, "-150");
+        tst(-150_i128, "-150");
+        tst(-150_isize, "-150");
     }
 
     #[test]


### PR DESCRIPTION
These seem arbitrarily left out, which means you need to jump through a few additional hoops if you want, for example, `Mpz::from(vec.len())` or the like.