### PR TITLE
Clear Clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![crate_name = "gmp"]
-
 #![warn(deprecated)]
 #![allow(non_camel_case_types)]
 
@@ -7,9 +6,9 @@ extern crate libc;
 extern crate num_traits;
 
 mod ffi;
-pub mod mpz;
-pub mod mpq;
 pub mod mpf;
+pub mod mpq;
+pub mod mpz;
 pub mod rand;
 pub mod sign;
 

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -93,7 +93,7 @@ impl Mpf {
         unsafe {
             let mut mpf = uninitialized();
             __gmpf_init2(&mut mpf, precision as c_ulong);
-            Mpf { mpf: mpf }
+            Mpf { mpf }
         }
     }
 
@@ -219,7 +219,7 @@ impl Clone for Mpf {
         unsafe {
             let mut mpf = uninitialized();
             __gmpf_init_set(&mut mpf, &self.mpf);
-            Mpf { mpf: mpf }
+            Mpf { mpf }
         }
     }
 }

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -8,7 +8,7 @@ use std;
 use std::cmp;
 use std::cmp::Ordering::{self, Equal, Greater, Less};
 use std::ffi::CString;
-use std::mem::uninitialized;
+use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use std::string::String;
 
@@ -90,9 +90,10 @@ impl Mpf {
     }
 
     pub fn new(precision: usize) -> Mpf {
+        let mut mpf = MaybeUninit::uninit();
         unsafe {
-            let mut mpf = uninitialized();
-            __gmpf_init2(&mut mpf, precision as c_ulong);
+            __gmpf_init2(mpf.as_mut_ptr(), precision as c_ulong);
+            let mpf = mpf.assume_init();
             Mpf { mpf }
         }
     }
@@ -216,9 +217,10 @@ impl Mpf {
 
 impl Clone for Mpf {
     fn clone(&self) -> Mpf {
+        let mut mpf = MaybeUninit::uninit();
         unsafe {
-            let mut mpf = uninitialized();
-            __gmpf_init_set(&mut mpf, &self.mpf);
+            __gmpf_init_set(mpf.as_mut_ptr(), &self.mpf);
+            let mpf = mpf.assume_init();
             Mpf { mpf }
         }
     }

--- a/src/mpf.rs
+++ b/src/mpf.rs
@@ -6,7 +6,7 @@ use libc::{c_char, c_double, c_int, c_long, c_ulong, c_void, free};
 use num_traits::{One, Zero};
 use std;
 use std::cmp;
-use std::cmp::Ordering::{self, Equal, Greater, Less};
+use std::cmp::Ordering;
 use std::ffi::CString;
 use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -204,13 +204,10 @@ impl Mpf {
     }
 
     pub fn sign(&self) -> Sign {
-        let size = self.mpf._mp_size;
-        if size == 0 {
-            Sign::Zero
-        } else if size > 0 {
-            Sign::Positive
-        } else {
-            Sign::Negative
+        match self.mpf._mp_size.cmp(&0) {
+            Ordering::Less => Sign::Negative,
+            Ordering::Equal => Sign::Zero,
+            Ordering::Greater => Sign::Positive,
         }
     }
 }
@@ -236,13 +233,7 @@ impl PartialEq for Mpf {
 impl Ord for Mpf {
     fn cmp(&self, other: &Mpf) -> Ordering {
         let cmp = unsafe { __gmpf_cmp(&self.mpf, &other.mpf) };
-        if cmp == 0 {
-            Equal
-        } else if cmp > 0 {
-            Greater
-        } else {
-            Less
-        }
+        cmp.cmp(&0)
     }
 }
 

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -203,19 +203,11 @@ pub struct ParseMpqError {
 
 impl fmt::Display for ParseMpqError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        write!(f, "invalid rational number")
     }
 }
 
-impl Error for ParseMpqError {
-    fn description(&self) -> &'static str {
-        "invalid rational number"
-    }
-
-    fn cause(&self) -> Option<&'static dyn Error> {
-        None
-    }
-}
+impl Error for ParseMpqError {}
 
 impl Clone for Mpq {
     fn clone(&self) -> Mpq {

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -76,7 +76,7 @@ impl Mpq {
         unsafe {
             let mut mpq = uninitialized();
             __gmpq_init(&mut mpq);
-            Mpq { mpq: mpq }
+            Mpq { mpq }
         }
     }
 

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -9,7 +9,7 @@ use std::convert::From;
 use std::error::Error;
 use std::ffi::CString;
 use std::fmt;
-use std::mem::uninitialized;
+use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use std::str::FromStr;
 
@@ -73,9 +73,11 @@ impl Mpq {
     }
 
     pub fn new() -> Mpq {
+        let mut mpq = MaybeUninit::uninit();
         unsafe {
-            let mut mpq = uninitialized();
-            __gmpq_init(&mut mpq);
+            __gmpq_init(mpq.as_mut_ptr());
+            let mpq = mpq.assume_init();
+
             Mpq { mpq }
         }
     }

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -4,7 +4,7 @@ use super::sign::Sign;
 use ffi::*;
 use libc::{c_char, c_double, c_int, c_ulong};
 use num_traits::{One, Zero};
-use std::cmp::Ordering::{self, Equal, Greater, Less};
+use std::cmp::Ordering;
 use std::convert::From;
 use std::error::Error;
 use std::ffi::CString;
@@ -227,13 +227,7 @@ impl PartialEq for Mpq {
 impl Ord for Mpq {
     fn cmp(&self, other: &Mpq) -> Ordering {
         let cmp = unsafe { __gmpq_cmp(&self.mpq, &other.mpq) };
-        if cmp == 0 {
-            Equal
-        } else if cmp < 0 {
-            Less
-        } else {
-            Greater
-        }
+        cmp.cmp(&0)
     }
 }
 impl PartialOrd for Mpq {

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -210,7 +210,7 @@ impl Error for ParseMpqError {
         "invalid rational number"
     }
 
-    fn cause(&self) -> Option<&'static Error> {
+    fn cause(&self) -> Option<&'static dyn Error> {
         None
     }
 }

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -1,22 +1,22 @@
-use super::mpz::{mpz_struct, Mpz, mpz_ptr, mpz_srcptr};
-use super::mpf::{Mpf, mpf_srcptr};
+use super::mpf::{mpf_srcptr, Mpf};
+use super::mpz::{mpz_ptr, mpz_srcptr, mpz_struct, Mpz};
 use super::sign::Sign;
 use ffi::*;
 use libc::{c_char, c_double, c_int, c_ulong};
-use std::ffi::CString;
-use std::str::FromStr;
-use std::error::Error;
+use num_traits::{One, Zero};
+use std::cmp::Ordering::{self, Equal, Greater, Less};
 use std::convert::From;
-use std::mem::uninitialized;
+use std::error::Error;
+use std::ffi::CString;
 use std::fmt;
-use std::cmp::Ordering::{self, Greater, Less, Equal};
-use std::ops::{Div, DivAssign, Mul, MulAssign, Add, AddAssign, Sub, SubAssign, Neg};
-use num_traits::{Zero, One};
+use std::mem::uninitialized;
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::str::FromStr;
 
 #[repr(C)]
 pub struct mpq_struct {
     _mp_num: mpz_struct,
-    _mp_den: mpz_struct
+    _mp_den: mpz_struct,
 }
 
 pub type mpq_srcptr = *const mpq_struct;
@@ -54,11 +54,13 @@ pub struct Mpq {
     mpq: mpq_struct,
 }
 
-unsafe impl Send for Mpq { }
-unsafe impl Sync for Mpq { }
+unsafe impl Send for Mpq {}
+unsafe impl Sync for Mpq {}
 
 impl Drop for Mpq {
-    fn drop(&mut self) { unsafe { __gmpq_clear(&mut self.mpq) } }
+    fn drop(&mut self) {
+        unsafe { __gmpq_clear(&mut self.mpq) }
+    }
 }
 
 impl Mpq {
@@ -184,7 +186,9 @@ impl Mpq {
         res
     }
 
-    pub fn zero() -> Mpq { Mpq::new() }
+    pub fn zero() -> Mpq {
+        Mpq::new()
+    }
     pub fn is_zero(&self) -> bool {
         unsafe { __gmpq_cmp_ui(&self.mpq, 0, 1) == 0 }
     }
@@ -192,7 +196,7 @@ impl Mpq {
 
 #[derive(Debug)]
 pub struct ParseMpqError {
-    _priv: ()
+    _priv: (),
 }
 
 impl fmt::Display for ParseMpqError {
@@ -219,7 +223,7 @@ impl Clone for Mpq {
     }
 }
 
-impl Eq for Mpq { }
+impl Eq for Mpq {}
 impl PartialEq for Mpq {
     fn eq(&self, other: &Mpq) -> bool {
         unsafe { __gmpq_equal(&self.mpq, &other.mpq) != 0 }
@@ -250,7 +254,7 @@ macro_rules! div_guard {
             panic!("divide by zero")
         }
     };
-    ($tr: ident, $what: expr) => {}
+    ($tr: ident, $what: expr) => {};
 }
 
 macro_rules! impl_oper {
@@ -312,7 +316,7 @@ macro_rules! impl_oper {
                 }
             }
         }
-    }
+    };
 }
 
 impl_oper!(Add, add, AddAssign, add_assign, __gmpq_add);
@@ -350,9 +354,7 @@ impl From<Mpq> for f64 {
 
 impl<'a> From<&'a Mpq> for f64 {
     fn from(other: &Mpq) -> f64 {
-        unsafe {
-            __gmpq_get_d(&other.mpq) as f64
-        }
+        unsafe { __gmpq_get_d(&other.mpq) as f64 }
     }
 }
 
@@ -400,7 +402,6 @@ impl FromStr for Mpq {
         Mpq::from_str_radix(s, 10)
     }
 }
-
 
 impl fmt::Debug for Mpq {
     /// Renders as `numer/denom`. If denom=1, renders as numer.

--- a/src/mpq.rs
+++ b/src/mpq.rs
@@ -97,7 +97,7 @@ impl Mpq {
         let s = CString::new(s).map_err(|_| ParseMpqError { _priv: () })?;
         let mut res = Mpq::new();
         unsafe {
-            assert!(base == 0 || (base >= 2 && base <= 62));
+            assert!(base == 0 || (2..=62).contains(&base));
             let r = __gmpq_set_str(&mut res.mpq, s.as_ptr(), base as c_int);
 
             if r == 0 {

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -148,7 +148,7 @@ impl Mpz {
         unsafe {
             let mut mpz = uninitialized();
             __gmpz_init(&mut mpz);
-            Mpz { mpz: mpz }
+            Mpz { mpz }
         }
     }
 
@@ -156,7 +156,7 @@ impl Mpz {
         unsafe {
             let mut mpz = uninitialized();
             __gmpz_init2(&mut mpz, n as c_ulong);
-            Mpz { mpz: mpz }
+            Mpz { mpz }
         }
     }
 
@@ -210,7 +210,7 @@ impl Mpz {
             let mut mpz = uninitialized();
             let r = __gmpz_init_set_str(&mut mpz, s.as_ptr(), base as c_int);
             if r == 0 {
-                Ok(Mpz { mpz: mpz })
+                Ok(Mpz { mpz })
             } else {
                 __gmpz_clear(&mut mpz);
                 Err(ParseMpzError { _priv: () })
@@ -450,7 +450,7 @@ impl Mpz {
         unsafe {
             let mut mpz = uninitialized();
             __gmpz_init_set_ui(&mut mpz, 1);
-            Mpz { mpz: mpz }
+            Mpz { mpz }
         }
     }
 
@@ -489,7 +489,7 @@ impl Clone for Mpz {
         unsafe {
             let mut mpz = uninitialized();
             __gmpz_init_set(&mut mpz, &self.mpz);
-            Mpz { mpz: mpz }
+            Mpz { mpz }
         }
     }
 }

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -212,7 +212,7 @@ impl Mpz {
         let s = CString::new(s.to_string()).map_err(|_| ParseMpzError { _priv: () })?;
         let mut mpz = MaybeUninit::uninit();
         unsafe {
-            assert!(base == 0 || (base >= 2 && base <= 62));
+            assert!(base == 0 || (2..=62).contains(&base));
 
             let r = __gmpz_init_set_str(mpz.as_mut_ptr(), s.as_ptr(), base as c_int);
             if r != 0 {
@@ -232,7 +232,7 @@ impl Mpz {
 
     // TODO: too easy to forget to check this return value - rename?
     pub fn set_from_str_radix(&mut self, s: &str, base: u8) -> bool {
-        assert!(base == 0 || (base >= 2 && base <= 62));
+        assert!(base == 0 || (2..=62).contains(&base));
         let s = CString::new(s.to_string()).unwrap();
         unsafe { __gmpz_set_str(&mut self.mpz, s.as_ptr(), base as c_int) == 0 }
     }

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -412,11 +412,8 @@ impl Mpz {
         assert!(self.mpz._mp_size >= 0);
         unsafe {
             let mut res = Mpz::new();
-            let _perfect_root = match __gmpz_root(&mut res.mpz, &self.mpz, n as c_ulong) {
-                0 => false,
-                _ => true,
-            };
-            // TODO: consider returning `_perfect_root`
+            // TODO: Consider returning this return value (non-zero == perfect root)
+            __gmpz_root(&mut res.mpz, &self.mpz, n as c_ulong);
             res
         }
     }

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -819,7 +819,7 @@ impl<'b> From<&'b Mpz> for Option<i64> {
                     Some(result)
                 }
             } else {
-                return None;
+                None
             }
         }
     }

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -189,18 +189,9 @@ impl Mpz {
 
             __gmpz_get_str(vector.as_mut_ptr() as *mut _, base as c_int, &self.mpz);
 
-            let mut first_nul = None;
-            let mut index: usize = 0;
-            for elem in &vector {
-                if *elem == 0 {
-                    first_nul = Some(index);
-                    break;
-                }
-                index += 1;
-            }
-            let first_nul = first_nul.unwrap_or(len);
-
+            let first_nul = vector.iter().position(|elem| *elem == 0).unwrap_or(len);
             vector.truncate(first_nul);
+
             match String::from_utf8(vector) {
                 Ok(s) => s,
                 Err(_) => panic!("GMP returned invalid UTF-8!"),

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -2,7 +2,7 @@ use super::rand::gmp_randstate_t;
 use super::sign::Sign;
 use libc::{c_char, c_double, c_int, c_long, c_ulong, c_void, size_t};
 use num_traits::{One, Zero};
-use std::cmp::Ordering::{self, Equal, Greater, Less};
+use std::cmp::Ordering;
 use std::convert::From;
 use std::error::Error;
 use std::ffi::CString;
@@ -444,13 +444,10 @@ impl Mpz {
     }
 
     pub fn sign(&self) -> Sign {
-        let size = self.mpz._mp_size;
-        if size == 0 {
-            Sign::Zero
-        } else if size > 0 {
-            Sign::Positive
-        } else {
-            Sign::Negative
+        match self.mpz._mp_size.cmp(&0) {
+            Ordering::Less => Sign::Negative,
+            Ordering::Equal => Sign::Zero,
+            Ordering::Greater => Sign::Positive,
         }
     }
 
@@ -509,13 +506,7 @@ impl PartialEq for Mpz {
 impl Ord for Mpz {
     fn cmp(&self, other: &Mpz) -> Ordering {
         let cmp = unsafe { __gmpz_cmp(&self.mpz, &other.mpz) };
-        if cmp == 0 {
-            Equal
-        } else if cmp < 0 {
-            Less
-        } else {
-            Greater
-        }
+        cmp.cmp(&0)
     }
 }
 

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -479,7 +479,7 @@ impl Error for ParseMpzError {
         "invalid integer"
     }
 
-    fn cause(&self) -> Option<&'static Error> {
+    fn cause(&self) -> Option<&'static dyn Error> {
         None
     }
 }

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -12,6 +12,7 @@ use std::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
 };
+use std::ptr;
 use std::str::FromStr;
 use std::{fmt, hash};
 use std::{i32, u32};
@@ -777,7 +778,7 @@ impl<'b> From<&'b Mpz> for Vec<u8> {
             let mut result: Vec<u8> = vec![0; size];
             __gmpz_export(
                 result.as_mut_ptr() as *mut c_void,
-                0 as *mut size_t,
+                ptr::null_mut::<size_t>(),
                 1,
                 size_of::<u8>() as size_t,
                 0,
@@ -805,7 +806,7 @@ impl<'b> From<&'b Mpz> for Option<i64> {
                 let mut result: i64 = 0;
                 __gmpz_export(
                     &mut result as *mut i64 as *mut c_void,
-                    0 as *mut size_t,
+                    ptr::null_mut::<size_t>(),
                     -1,
                     size_of::<i64>() as size_t,
                     0,
@@ -831,7 +832,7 @@ impl<'b> From<&'b Mpz> for Option<u64> {
                 let mut result: u64 = 0;
                 __gmpz_export(
                     &mut result as *mut u64 as *mut c_void,
-                    0 as *mut size_t,
+                    ptr::null_mut::<size_t>(),
                     -1,
                     size_of::<u64>() as size_t,
                     0,

--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -480,19 +480,11 @@ pub struct ParseMpzError {
 
 impl fmt::Display for ParseMpzError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        write!(f, "invalid integer")
     }
 }
 
-impl Error for ParseMpzError {
-    fn description(&self) -> &'static str {
-        "invalid integer"
-    }
-
-    fn cause(&self) -> Option<&'static dyn Error> {
-        None
-    }
-}
+impl Error for ParseMpzError {}
 
 impl Clone for Mpz {
     fn clone(&self) -> Mpz {

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -48,7 +48,7 @@ impl RandState {
         unsafe {
             let mut state: gmp_randstate_struct = uninitialized();
             __gmp_randinit_default(&mut state);
-            RandState { state: state }
+            RandState { state }
         }
     }
 
@@ -56,7 +56,7 @@ impl RandState {
         unsafe {
             let mut state: gmp_randstate_struct = uninitialized();
             __gmp_randinit_mt(&mut state);
-            RandState { state: state }
+            RandState { state }
         }
     }
 
@@ -64,7 +64,7 @@ impl RandState {
         unsafe {
             let mut state: gmp_randstate_struct = uninitialized();
             __gmp_randinit_lc_2exp(&mut state, a.inner(), c as c_ulong, m2exp as c_ulong);
-            RandState { state: state }
+            RandState { state }
         }
     }
 
@@ -72,7 +72,7 @@ impl RandState {
         unsafe {
             let mut state: gmp_randstate_struct = uninitialized();
             __gmp_randinit_lc_2exp_size(&mut state, size as c_ulong);
-            RandState { state: state }
+            RandState { state }
         }
     }
 
@@ -108,7 +108,7 @@ impl Clone for RandState {
         unsafe {
             let mut state: gmp_randstate_struct = uninitialized();
             __gmp_randinit_set(&mut state, &self.state);
-            RandState { state: state }
+            RandState { state }
         }
     }
 }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,12 +1,12 @@
+use super::mpz::{mp_bitcnt_t, mpz_ptr, mpz_srcptr, mpz_struct, Mpz};
 use libc::{c_int, c_ulong, c_void};
-use super::mpz::{mpz_struct, Mpz, mpz_ptr, mpz_srcptr, mp_bitcnt_t};
 use std::mem::uninitialized;
 
 #[repr(C)]
 pub struct gmp_randstate_struct {
     _mp_seed: mpz_struct,
     _mp_alg: c_int,
-    _mp_algdata: *const c_void
+    _mp_algdata: *const c_void,
 }
 
 pub type gmp_randstate_t = *mut gmp_randstate_struct;
@@ -15,7 +15,12 @@ pub type gmp_randstate_t = *mut gmp_randstate_struct;
 extern "C" {
     fn __gmp_randinit_default(state: gmp_randstate_t);
     fn __gmp_randinit_mt(state: gmp_randstate_t);
-    fn __gmp_randinit_lc_2exp(state: gmp_randstate_t, a: mpz_srcptr, c: c_ulong, m2exp: mp_bitcnt_t);
+    fn __gmp_randinit_lc_2exp(
+        state: gmp_randstate_t,
+        a: mpz_srcptr,
+        c: c_ulong,
+        m2exp: mp_bitcnt_t,
+    );
     fn __gmp_randinit_lc_2exp_size(state: gmp_randstate_t, size: mp_bitcnt_t);
     fn __gmp_randinit_set(state: gmp_randstate_t, op: *const gmp_randstate_struct);
     fn __gmp_randclear(state: gmp_randstate_t);
@@ -29,8 +34,8 @@ pub struct RandState {
     state: gmp_randstate_struct,
 }
 
-unsafe impl Send for RandState { }
-unsafe impl Sync for RandState { }
+unsafe impl Send for RandState {}
+unsafe impl Sync for RandState {}
 
 impl Drop for RandState {
     fn drop(&mut self) {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -4,4 +4,3 @@ pub enum Sign {
     Zero,
     Positive,
 }
-

--- a/src/test.rs
+++ b/src/test.rs
@@ -425,6 +425,7 @@ mod mpz {
         assert!(onea == oneb);
     }
 
+    #[allow(clippy::needless_range_loop)] // Range loop is cleaner.
     #[test]
     fn test_bit_fiddling() {
         let mut xs: Mpz = From::<i64>::from(0b1010_1000_0010_0011);

--- a/src/test.rs
+++ b/src/test.rs
@@ -314,7 +314,7 @@ mod mpz {
 
     #[test]
     fn test_popcount() {
-        Mpz::from_str_radix("1010010011", 2).unwrap().popcount() == 5;
+        assert_eq!(Mpz::from_str_radix("1010010011", 2).unwrap().popcount(), 5);
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 use super::mpz::mp_limb_t;
-use std;
 use libc::c_int;
+use std;
 
 #[link(name = "gmp")]
 extern "C" {
@@ -10,20 +10,21 @@ extern "C" {
 #[test]
 fn test_limb_size() {
     // We are assuming that the limb size is the same as the pointer size.
-    assert_eq!(std::mem::size_of::<mp_limb_t>() * 8,
-               unsafe { __gmp_bits_per_limb as usize });
+    assert_eq!(std::mem::size_of::<mp_limb_t>() * 8, unsafe {
+        __gmp_bits_per_limb as usize
+    });
 }
 
 mod mpz {
     use super::super::mpz::Mpz;
     use super::super::mpz::ProbabPrimeResult;
     use super::super::sign::Sign;
-    use std::str::FromStr;
     use std::convert::{From, Into};
+    use std::str::FromStr;
     use std::{i64, u64};
 
-    use std::hash::{Hash, Hasher};
     use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
 
     #[test]
     fn test_set() {
@@ -126,35 +127,35 @@ mod mpz {
         assert!((&x % -&y).to_string() == (20i32 % -3).to_string());
         assert!((-&x % &y).to_string() == (-20i32 % 3).to_string());
     }
-    
+
     #[test]
     fn test_add() {
-    	let x: Mpz = From::<i64>::from(2);
-    	let y: Mpz = From::<i64>::from(3);
-    	let str5 = 5i32.to_string();
-    	assert!((&x + &y).to_string() == str5);
-    	assert!((&x + 3).to_string() == str5);
-    	assert!((&y + 2).to_string() == str5);
+        let x: Mpz = From::<i64>::from(2);
+        let y: Mpz = From::<i64>::from(3);
+        let str5 = 5i32.to_string();
+        assert!((&x + &y).to_string() == str5);
+        assert!((&x + 3).to_string() == str5);
+        assert!((&y + 2).to_string() == str5);
     }
-    
+
     #[test]
     fn test_sub() {
-    	let x: Mpz = From::<i64>::from(2);
-    	let y: Mpz = From::<i64>::from(3);
-    	assert!((&x - &y).to_string() == (-1i32).to_string());
-    	assert!((&y - &x).to_string() == 1i32.to_string());
-    	assert!((&y - 8).to_string() == (-5i32).to_string());
+        let x: Mpz = From::<i64>::from(2);
+        let y: Mpz = From::<i64>::from(3);
+        assert!((&x - &y).to_string() == (-1i32).to_string());
+        assert!((&y - &x).to_string() == 1i32.to_string());
+        assert!((&y - 8).to_string() == (-5i32).to_string());
     }
-    
+
     #[test]
     fn test_mul() {
-    	let x: Mpz = From::<i64>::from(2);
-    	let y: Mpz = From::<i64>::from(3);
-    	assert!((&x * &y).to_string() == 6i32.to_string());
-    	assert!((&x * 3i64).to_string() == 6i32.to_string());
-    	assert!((&y * -5i64).to_string() == (-15i32).to_string());
-    	// check with values not fitting in 32 bits
-    	assert!((&x * 5000000000i64).to_string() == 10000000000i64.to_string());
+        let x: Mpz = From::<i64>::from(2);
+        let y: Mpz = From::<i64>::from(3);
+        assert!((&x * &y).to_string() == 6i32.to_string());
+        assert!((&x * 3i64).to_string() == 6i32.to_string());
+        assert!((&y * -5i64).to_string() == (-15i32).to_string());
+        // check with values not fitting in 32 bits
+        assert!((&x * 5000000000i64).to_string() == 10000000000i64.to_string());
     }
 
     #[test]
@@ -193,7 +194,7 @@ mod mpz {
 
     #[test]
     fn test_from_slice_u8() {
-        let v: Vec<u8> = vec!(255, 255);
+        let v: Vec<u8> = vec![255, 255];
         let x: Mpz = From::from(&v[..]);
         assert!(x.to_string() == "65535".to_string());
     }
@@ -335,7 +336,7 @@ mod mpz {
     fn test_probab_prime() {
         let prime: Mpz = From::<i64>::from(2);
         assert!(prime.probab_prime(15) == ProbabPrimeResult::Prime);
-        
+
         let not_prime: Mpz = From::<i64>::from(4);
         assert!(not_prime.probab_prime(15) == ProbabPrimeResult::NotPrime);
     }
@@ -366,7 +367,7 @@ mod mpz {
         let twentyfour: Mpz = From::<i64>::from(24);
         let (g, s, t) = eighteen.gcdext(&twentyfour);
         assert!(g == six);
-        assert!(g == s*eighteen + t*twentyfour);
+        assert!(g == s * eighteen + t * twentyfour);
     }
 
     #[test]
@@ -428,10 +429,10 @@ mod mpz {
     fn test_bit_fiddling() {
         let mut xs: Mpz = From::<i64>::from(0b1010_1000_0010_0011);
         assert!(xs.bit_length() == 16);
-        let mut ys = [true, false, true, false,
-                      true, false, false, false,
-                      false, false, true, false,
-                      false, false, true, true];
+        let mut ys = [
+            true, false, true, false, true, false, false, false, false, false, true, false, false,
+            false, true, true,
+        ];
         ys.reverse();
         for i in 0..xs.bit_length() {
             assert!(xs.tstbit(i) == ys[i]);
@@ -473,7 +474,7 @@ mod mpz {
         let one: Mpz = From::<i64>::from(1);
         let two = &one + &one;
 
-        let hash = |x : &Mpz| {
+        let hash = |x: &Mpz| {
             let mut hasher = DefaultHasher::new();
             x.hash(&mut hasher);
             hasher.finish()
@@ -485,13 +486,11 @@ mod mpz {
 
     #[test]
     fn test_hash_long() {
-        let a = Mpz::from_str_radix("348917329847193287498312749187234192387", 10)
-                .unwrap();
-        let b = Mpz::from_str_radix("348917329847193287498312749187234192386", 10)
-                .unwrap();
+        let a = Mpz::from_str_radix("348917329847193287498312749187234192387", 10).unwrap();
+        let b = Mpz::from_str_radix("348917329847193287498312749187234192386", 10).unwrap();
         let one: Mpz = From::<i64>::from(1);
 
-        let hash = |x : &Mpz| {
+        let hash = |x: &Mpz| {
             let mut hasher = DefaultHasher::new();
             x.hash(&mut hasher);
             hasher.finish()
@@ -518,7 +517,10 @@ mod mpz {
         assert_eq!(Into::<Vec<u8>>::into(&one), vec!(1u8));
         assert_eq!(Into::<Vec<u8>>::into(&five), vec!(5u8));
         assert_eq!(Into::<Vec<u8>>::into(&xffff), vec!(255u8, 255u8));
-        assert_eq!(Into::<Vec<u8>>::into(&max_u64), vec!(255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8));
+        assert_eq!(
+            Into::<Vec<u8>>::into(&max_u64),
+            vec!(255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8, 255u8)
+        );
     }
 
     #[test]
@@ -573,9 +575,9 @@ mod mpz {
 }
 
 mod rand {
-    use std::convert::From;
     use super::super::mpz::Mpz;
     use super::super::rand::RandState;
+    use std::convert::From;
 
     #[test]
     fn test_randstate() {
@@ -591,11 +593,11 @@ mod rand {
 }
 
 mod mpq {
-    use std::convert::From;
-    use std::u64;
     use super::super::mpq::Mpq;
     use super::super::mpz::Mpz;
     use super::super::sign::Sign;
+    use std::convert::From;
+    use std::u64;
 
     #[test]
     fn test_one() {
@@ -684,9 +686,18 @@ mod mpq {
         let minus_one = -&one;
         let two = &one + &one;
 
-        assert_eq!(Mpq::from_str_radix("1/-1", 10).unwrap(), Mpq::ratio(&minus_one, &one));
-        assert_eq!(Mpq::from_str_radix("0/2", 10).unwrap(), Mpq::ratio(&zero, &one));
-        assert_eq!(Mpq::from_str_radix("2/4", 10).unwrap(), Mpq::ratio(&one, &two));
+        assert_eq!(
+            Mpq::from_str_radix("1/-1", 10).unwrap(),
+            Mpq::ratio(&minus_one, &one)
+        );
+        assert_eq!(
+            Mpq::from_str_radix("0/2", 10).unwrap(),
+            Mpq::ratio(&zero, &one)
+        );
+        assert_eq!(
+            Mpq::from_str_radix("2/4", 10).unwrap(),
+            Mpq::ratio(&one, &two)
+        );
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -161,13 +161,13 @@ mod mpz {
     #[test]
     fn test_to_str_radix() {
         let x: Mpz = From::<i64>::from(255);
-        assert!(x.to_str_radix(16) == "ff".to_string());
+        assert_eq!(x.to_str_radix(16), "ff");
     }
 
     #[test]
     fn test_to_string() {
         let x: Mpz = FromStr::from_str("1234567890").unwrap();
-        assert!(x.to_string() == "1234567890".to_string());
+        assert_eq!(x.to_string(), "1234567890");
     }
 
     #[test]
@@ -188,7 +188,7 @@ mod mpz {
     #[test]
     fn test_from_int() {
         let x: Mpz = From::<i64>::from(150);
-        assert!(x.to_string() == "150".to_string());
+        assert_eq!(x.to_string(), "150");
         assert!(x == FromStr::from_str("150").unwrap());
     }
 
@@ -196,7 +196,7 @@ mod mpz {
     fn test_from_slice_u8() {
         let v: Vec<u8> = vec![255, 255];
         let x: Mpz = From::from(&v[..]);
-        assert!(x.to_string() == "65535".to_string());
+        assert_eq!(x.to_string(), "65535");
     }
 
     #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -82,6 +82,7 @@ mod mpz {
         assert!(y != z);
     }
 
+    #[allow(clippy::eq_op)] // We are testing the operator implementation.
     #[test]
     fn test_ord() {
         let x: Mpz = FromStr::from_str("40000000000000000000000").unwrap();
@@ -485,6 +486,7 @@ mod mpz {
         assert_eq!(hash(&one), hash(&(&two - &one)));
     }
 
+    #[allow(clippy::eq_op)] // We are testing the operator implementation.
     #[test]
     fn test_hash_long() {
         let a = Mpz::from_str_radix("348917329847193287498312749187234192387", 10).unwrap();
@@ -706,6 +708,7 @@ mod mpf {
     use super::super::mpf::Mpf;
     use super::super::sign::Sign;
 
+    #[allow(clippy::eq_op)] // We are testing the operator implementation.
     #[test]
     #[should_panic]
     fn test_div_zero() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -99,7 +99,7 @@ mod mpz {
     fn test_div_zero() {
         let x: Mpz = From::<i64>::from(1);
         let y = Mpz::new();
-        x / y;
+        let _ = x / y;
     }
 
     #[test]
@@ -107,7 +107,7 @@ mod mpz {
     fn test_rem_zero() {
         let x: Mpz = From::<i64>::from(1);
         let y = Mpz::new();
-        x % y;
+        let _ = x % y;
     }
 
     #[test]
@@ -612,7 +612,7 @@ mod mpq {
     fn test_div_zero() {
         let x: Mpq = From::<i64>::from(1);
         let y = Mpq::new();
-        x / y;
+        let _ = x / y;
     }
 
     #[test]
@@ -710,7 +710,7 @@ mod mpf {
     #[should_panic]
     fn test_div_zero() {
         let x = Mpf::new(0);
-        &x / &x;
+        let _ = &x / &x;
     }
 
     #[test]


### PR DESCRIPTION
This PR clears all Clippy warnings (incl. nightly) except for documentation of unsafe

```
warning: unsafe function's docs miss `# Safety` section
```
 
Please note, the first patch runs `cargo fmt` if that is not wanted I can remove it.

Commit `d7f6956 Use std::mem::MaybeUninit` needs special attention please.

This is kinda a big PR for my first one so if you'd like me to split the more trivial patches out into a separate PR I can do that also.

Thanks