### PR TITLE
Use must_use

### DIFF
--- a/src/mpz.rs
+++ b/src/mpz.rs
@@ -205,7 +205,7 @@ impl Mpz {
         unsafe { __gmpz_set(&mut self.mpz, &other.mpz) }
     }
 
-    // TODO: too easy to forget to check this return value - rename?
+    #[must_use]
     pub fn set_from_str_radix(&mut self, s: &str, base: u8) -> bool {
         assert!(base == 0 || (base >= 2 && base <= 62));
         let s = CString::new(s.to_string()).unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -60,14 +60,14 @@ mod mpz {
     #[should_panic]
     fn test_set_from_str_radix_lower_bound() {
         let mut x = Mpz::new();
-        x.set_from_str_radix("", 1);
+        let _ = x.set_from_str_radix("", 1);
     }
 
     #[test]
     #[should_panic]
     fn test_set_from_str_radix_upper_bound() {
         let mut x = Mpz::new();
-        x.set_from_str_radix("", 63);
+        let _ = x.set_from_str_radix("", 63);
     }
 
     #[test]


### PR DESCRIPTION
We have a TODO that hints at using `must_use`.

Use attribute `must_use` to warn users if they do not use the return value of this function.